### PR TITLE
대시보드 유트브 api 연결및 채널 ID 요청 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "framer-motion": "^10.16.4",
-        "lucide-react": "^0.263.1",
+        "lucide-react": "^0.540.0",
         "motion": "^10.16.2",
         "react": "^18.2.0",
         "react-day-picker": "^8.10.1",
@@ -5769,12 +5769,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.263.1",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.263.1.tgz",
-      "integrity": "sha512-keqxAx97PlaEN89PXZ6ki1N8nRjGWtDa4021GFYLNj0RgruM5odbpl8GHTExj0hhPq3sF6Up0gnxt6TSHu+ovw==",
+      "version": "0.540.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.540.0.tgz",
+      "integrity": "sha512-armkCAqQvO62EIX4Hq7hqX/q11WSZu0Jd23cnnqx0/49yIxGXyL/zyZfBxNN9YDx0ensPTb4L+DjTh3yQXUxtQ==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "framer-motion": "^10.16.4",
-    "lucide-react": "^0.263.1",
+    "lucide-react": "^0.540.0",
     "motion": "^10.16.2",
     "react": "^18.2.0",
     "react-day-picker": "^8.10.1",

--- a/src/components/dashboard/enhanced-platform-card.jsx
+++ b/src/components/dashboard/enhanced-platform-card.jsx
@@ -22,6 +22,9 @@ function EnhancedPlatformCard({ platform, index }) {
             <div>
               <h3 className="text-2xl font-semibold text-gray-800 dark:text-white">{platform.name}</h3>
               <p className="text-base text-gray-600 dark:text-gray-400">{platform.description}</p>
+              {platform.totalVideos !== undefined && (
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">총 영상: {platform.totalVideos}개</p>
+              )}
             </div>
           </div>
 

--- a/src/components/dashboard/enhanced-platform-card.jsx
+++ b/src/components/dashboard/enhanced-platform-card.jsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion';
 import { TrendingUp } from 'lucide-react';
-import { LineChart, Line, XAxis, YAxis, ResponsiveContainer, Tooltip } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, ResponsiveContainer, Tooltip as RechartsTooltip } from 'recharts';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../components/ui/tooltip.jsx';
 
 function EnhancedPlatformCard({ platform, index }) {
   const Icon = platform.icon;
@@ -56,9 +57,18 @@ function EnhancedPlatformCard({ platform, index }) {
               <div className="w-6 h-6 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center">
                 <TrendingUp className="w-4 h-4 text-green-600 dark:text-green-400" />
               </div>
-              <span className="text-green-600 dark:text-green-400 font-medium text-sm">
-                {platform.growth.value}
-              </span>
+              <TooltipProvider delayDuration={1000}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="text-green-600 dark:text-green-400 font-medium text-sm cursor-help">
+                      {platform.growth.value}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>참여율은 (좋아요 수 × 0.5 + 댓글 수 × 0.8) ÷ 조회수으로 계산됩니다.</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
             <span className="text-sm text-gray-500 dark:text-gray-400">
               {platform.growth.period}

--- a/src/components/dashboard/main_dashboard_view.jsx
+++ b/src/components/dashboard/main_dashboard_view.jsx
@@ -3,16 +3,46 @@
  * 메인 대시보드 뷰 (플랫폼 카드들)
  */
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { EnhancedPlatformCard } from "./enhanced-platform-card.jsx";
 import { get_platform_data } from '../../utils/dashboard_utils.js';
+import { getDashboardData } from '../../lib/api.js';
 
 /**
  * Main Dashboard View 컴포넌트
  * @returns {JSX.Element} Main Dashboard View 컴포넌트
  */
 const MainDashboardView = () => {
-  const platform_data = get_platform_data();
+  const [youtubeData, setYoutubeData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchYoutubeData = async () => {
+      try {
+        setLoading(true);
+        const data = await getDashboardData({ type: 'total' });
+        setYoutubeData(data.youtube.data); // Assuming data.youtube.data contains the relevant info
+      } catch (err) {
+        setError(err);
+        console.error("Failed to fetch YouTube dashboard data:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchYoutubeData();
+  }, []);
+
+  const platform_data = get_platform_data(youtubeData);
+
+  if (loading) {
+    return <div className="p-6 text-center text-gray-500 dark:text-gray-400">Loading dashboard data...</div>;
+  }
+
+  if (error) {
+    return <div className="p-6 text-center text-red-500 dark:text-red-400">Error: {error.message}</div>;
+  }
 
   return (
     <div className="p-6 relative z-10">

--- a/src/components/dashboard/main_dashboard_view.jsx
+++ b/src/components/dashboard/main_dashboard_view.jsx
@@ -8,6 +8,7 @@ import { EnhancedPlatformCard } from "./enhanced-platform-card.jsx";
 import { get_platform_data } from '../../utils/dashboard_utils.js';
 import { getDashboardData } from '../../lib/api.js';
 import { format, subDays } from 'date-fns';
+import { TooltipProvider } from '../../components/ui/tooltip.jsx';
 
 /**
  * Main Dashboard View 컴포넌트
@@ -49,17 +50,19 @@ const MainDashboardView = () => {
   }
 
   return (
-    <div className="p-6 relative z-10">
-      <div className="grid grid-cols-2 gap-6 h-[calc(100vh-200px)]">
-        {platform_data.map((platform, index) => (
-          <EnhancedPlatformCard 
-            key={platform.name} 
-            platform={platform} 
-            index={index}
-          />
-        ))}
+    <TooltipProvider>
+      <div className="p-6 relative z-10">
+        <div className="grid grid-cols-2 gap-6 h-[calc(100vh-200px)]">
+          {platform_data.map((platform, index) => (
+            <EnhancedPlatformCard 
+              key={platform.name} 
+              platform={platform} 
+              index={index}
+            />
+          ))}
+        </div>
       </div>
-    </div>
+    </TooltipProvider>
   );
 };
 

--- a/src/components/dashboard/main_dashboard_view.jsx
+++ b/src/components/dashboard/main_dashboard_view.jsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect } from 'react';
 import { EnhancedPlatformCard } from "./enhanced-platform-card.jsx";
 import { get_platform_data } from '../../utils/dashboard_utils.js';
 import { getDashboardData } from '../../lib/api.js';
+import { format, subDays } from 'date-fns';
 
 /**
  * Main Dashboard View 컴포넌트
@@ -21,7 +22,10 @@ const MainDashboardView = () => {
     const fetchYoutubeData = async () => {
       try {
         setLoading(true);
-        const data = await getDashboardData({ type: 'total' });
+        const endDate = format(new Date(), 'yyyy-MM-dd');
+        const startDate = format(subDays(new Date(), 6), 'yyyy-MM-dd'); // Last 7 days including today
+
+        const data = await getDashboardData({ type: 'range', startDate, endDate });
         setYoutubeData(data.youtube.data); // Assuming data.youtube.data contains the relevant info
       } catch (err) {
         setError(err);

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -5,24 +5,21 @@ import {
 let isRefreshing = false;
 let waitQueue = []; // { resolve, reject }
 
+/* ------------------ 토큰 갱신 ------------------ */
 async function refreshAccessToken() {
   if (isRefreshing) {
     return new Promise((resolve, reject) => waitQueue.push({ resolve, reject }));
   }
   isRefreshing = true;
   try {
-    // 쿠키 인증 방식에서는 브라우저가 자동으로 쿠키를 전송하므로,
-    // 요청 본문에 리프레시 토큰을 담을 필요가 없습니다.
     const res = await fetch('/api/auth/refresh', {
       method: 'POST',
-      // credentials: 'include' 옵션은 apiFetch 호출 시 자동으로 포함됩니다.
+      credentials: "include",
     });
     if (!res.ok) throw new Error(`Refresh failed: ${res.status}`);
 
     const { accessToken } = await res.json();
     setAccessToken(accessToken);
-    // 새로운 리프레시 토큰은 서버에서 HttpOnly 쿠키로 설정해 줄 것이므로,
-    // 클라이언트에서 별도로 저장할 필요가 없습니다.
 
     waitQueue.forEach(p => p.resolve(accessToken));
     waitQueue = [];
@@ -37,28 +34,90 @@ async function refreshAccessToken() {
   }
 }
 
-/**
- * 보호 API는 전부 이 함수로 호출하세요.
- * - Authorization 자동 첨부
- * - 401 발생 시 자동 리프레시 + 원요청 1회 재시도
- */
+/* ------------------ 공통 API Fetch ------------------ */
 export async function apiFetch(input, init = {}) {
   const headers = new Headers(init.headers || {});
   const at = getAccessToken();
   if (at) headers.set('Authorization', `Bearer ${at}`);
 
-  let res = await fetch(input, { ...init, headers });
-
+  let res = await fetch(input, { ...init, headers, credentials: "include" });
   if (res.status !== 401) return res;
 
-  // 401 → 리프레시 시도 → 성공 시 1회 재시도
+  // 401 발생 → 리프레시 시도 후 1회 재시도
   try {
     const newAT = await refreshAccessToken();
     const retryHeaders = new Headers(init.headers || {});
     if (newAT) retryHeaders.set('Authorization', `Bearer ${newAT}`);
-    return await fetch(input, { ...init, headers: retryHeaders });
+    return await fetch(input, { ...init, headers: retryHeaders, credentials: "include" });
   } catch {
-    // 리프레시 실패 → 호출부에서 로그인 화면으로 유도
-    return res;
+    return res; // 리프레시 실패 → 로그인 필요
+  }
+}
+
+/* ------------------ 대시보드 데이터 조회 ------------------ */
+/**
+ * @param {'daily' | 'range' | 'total'} type - 조회 유형
+ * @param {object} [options]
+ * @param {string} [options.date] - 단일 날짜 (YYYY-MM-DD)
+ * @param {string} [options.startDate] - 시작일 (YYYY-MM-DD)
+ * @param {string} [options.endDate] - 종료일 (YYYY-MM-DD)
+ * @param {string} [options.region] - 지역 필터
+ * @param {string} [options.channelId] - 채널 ID
+ */
+export async function getDashboardData({ type = 'total', ...options }) {
+  let url = '/api/dashboard/youtube';
+  const params = new URLSearchParams();
+
+  switch (type) {
+    case 'daily':
+      if (!options.date) throw new Error('Date is required for daily fetch');
+      params.append('date', options.date);
+      break;
+
+    case 'range':
+      if (!options.startDate || !options.endDate) {
+        throw new Error('Start date and end date are required for range fetch');
+      }
+      url += '/range';
+      params.append('startDate', options.startDate);
+      params.append('endDate', options.endDate);
+      break;
+
+    case 'total':
+      url += '/total';
+      break;
+
+    default:
+      throw new Error(`Invalid dashboard data type: ${type}`);
+  }
+
+  if (options.region) params.append('region', options.region);
+  if (options.channelId) params.append('channel_id', options.channelId);
+
+  const res = await apiFetch(`${url}?${params.toString()}`);
+
+  // ✅ 상태 코드별 처리
+  if (res.status === 400) {
+    throw new Error("잘못된 요청입니다. 날짜 형식을 확인하세요 (YYYY-MM-DD).");
+  }
+  if (!res.ok) {
+    throw new Error(`대시보드 데이터 조회 실패: ${res.status}`);
+  }
+
+  const rawData = await res.json();
+
+  // ✅ 타입별로 안전하게 래핑해서 반환
+  switch (type) {
+    case 'daily':
+      return { youtube: { type: 'daily', data: rawData } }; // DashboardDayStats
+
+    case 'range':
+      return { youtube: { type: 'range', data: rawData } }; // DashboardRangeStats
+
+    case 'total':
+      return { youtube: { type: 'total', data: rawData } }; // DashboardTotalStats
+
+    default:
+      return { youtube: rawData };
   }
 }

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -2,6 +2,7 @@ let accessTokenInMemory = null;
 
 export function setAccessToken(token) {
   accessTokenInMemory = token || null;
+  console.log("Current Access Token:", accessTokenInMemory);
 }
 export function getAccessToken() {
   return accessTokenInMemory;

--- a/src/stores/youtube_store.js
+++ b/src/stores/youtube_store.js
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+
+export const useYouTubeStore = create((set) => ({
+  channelId: null,
+  channelTitle: null,
+  setChannelInfo: (info) =>
+    set((state) => ({
+      ...state,
+      channelId: info.channelId,
+      channelTitle: info.channelTitle,
+    })),
+  clearChannelInfo: () =>
+    set((state) => ({
+      ...state,
+      channelId: null,
+      channelTitle: null,
+    })),
+}));

--- a/src/utils/dashboard_utils.js
+++ b/src/utils/dashboard_utils.js
@@ -100,9 +100,27 @@ export const get_kpi_data = (selected_platform) => {
  * @returns {Array} 플랫폼 데이터 배열
  */
 export const get_platform_data = (youtubeData) => {
+  let totalViews = youtubeData?.total?.total_view_count || 0;
+  let totalLikes = youtubeData?.total?.total_like_count || 0;
+  let totalComments = youtubeData?.total?.total_comment_count || 0;
+  let processedChartData = [];
+
+  if (youtubeData && Array.isArray(youtubeData.daily)) {
+    youtubeData.daily.forEach(dayData => {
+      processedChartData.push({
+        day: dayData.date, // Assuming 'date' is available and can be used as 'day'
+        views: dayData.view_count || 0,
+        likes: dayData.like_count || 0,
+      });
+    });
+  }
+
+  const engagementRate = (totalLikes && totalViews) ? ((totalLikes / totalViews) * 100).toFixed(2) : "0.00";
+
   const youtubePlatform = {
     name: "YouTube",
     description: "동영상 플랫폼",
+    totalVideos: youtubeData?.total?.total_video_count?.toLocaleString() || 0, // Total number of videos from the 'total' object
     status: "활성",
     statusColor: "text-green-500",
     icon: Play,
@@ -111,16 +129,16 @@ export const get_platform_data = (youtubeData) => {
     borderColor: "border-red-200/40 dark:border-red-800/30",
     accentColor: "text-red-600 dark:text-red-400",
     metrics: {
-      views: { value: youtubeData?.total_view_count?.toLocaleString() || "24.5K", label: "조회수", icon: Eye },
-      likes: { value: youtubeData?.total_like_count?.toLocaleString() || "3.2K", label: "좋아요", icon: Heart },
-      engagementRate: { value: ((youtubeData?.total_like_count && youtubeData?.total_view_count) ? ((youtubeData.total_like_count / youtubeData.total_view_count) * 100).toFixed(2) + '%' : "13.2%"), label: "참여율", icon: TrendingUp }
+      views: { value: totalViews.toLocaleString(), label: "조회수", icon: Eye },
+      likes: { value: totalLikes.toLocaleString(), label: "좋아요", icon: Heart },
+      comments: { value: totalComments.toLocaleString(), label: "총 댓글", icon: MessageSquare }
     },
     growth: {
-      value: "참여율 13.2%", // API does not provide growth data for total
+      value: `참여율 ${engagementRate}%`,
       period: "지난 7일",
-      isPositive: true
+      isPositive: true // This would need actual growth data to determine
     },
-    chartData: youtube_chart_data, // API does not provide chart data for total
+    chartData: processedChartData.length > 0 ? processedChartData : youtube_chart_data, // Use processed data if available, else fallback
     chartMetrics: {
       primary: { key: "views", label: "조회수", color: "#dc2626" },
       secondary: { key: "likes", label: "좋아요", color: "#7c3aed" }

--- a/src/utils/dashboard_utils.js
+++ b/src/utils/dashboard_utils.js
@@ -99,11 +99,11 @@ export const get_kpi_data = (selected_platform) => {
  * 플랫폼 데이터 생성
  * @returns {Array} 플랫폼 데이터 배열
  */
-export const get_platform_data = () => [
-  { 
-    name: "YouTube", 
+export const get_platform_data = (youtubeData) => {
+  const youtubePlatform = {
+    name: "YouTube",
     description: "동영상 플랫폼",
-    status: "활성", 
+    status: "활성",
     statusColor: "text-green-500",
     icon: Play,
     color: "from-red-500 to-red-600",
@@ -111,22 +111,23 @@ export const get_platform_data = () => [
     borderColor: "border-red-200/40 dark:border-red-800/30",
     accentColor: "text-red-600 dark:text-red-400",
     metrics: {
-      views: { value: "24.5K", label: "조회수", icon: Eye },
-      likes: { value: "3.2K", label: "좋아요", icon: Heart },
-      engagementRate: { value: "13.2%", label: "참여율", icon: TrendingUp }
+      views: { value: youtubeData?.total_view_count?.toLocaleString() || "24.5K", label: "조회수", icon: Eye },
+      likes: { value: youtubeData?.total_like_count?.toLocaleString() || "3.2K", label: "좋아요", icon: Heart },
+      engagementRate: { value: ((youtubeData?.total_like_count && youtubeData?.total_view_count) ? ((youtubeData.total_like_count / youtubeData.total_view_count) * 100).toFixed(2) + '%' : "13.2%"), label: "참여율", icon: TrendingUp }
     },
     growth: {
-      value: "참여율 13.2%",
+      value: "참여율 13.2%", // API does not provide growth data for total
       period: "지난 7일",
       isPositive: true
     },
-    chartData: youtube_chart_data,
+    chartData: youtube_chart_data, // API does not provide chart data for total
     chartMetrics: {
       primary: { key: "views", label: "조회수", color: "#dc2626" },
       secondary: { key: "likes", label: "좋아요", color: "#7c3aed" }
     }
-  },
-  { 
+  };
+
+  const redditPlatform = { 
     name: "Reddit", 
     description: "커뮤니티 플랫폼",
     status: "활성", 
@@ -151,8 +152,10 @@ export const get_platform_data = () => [
       primary: { key: "upvotes", label: "업보트", color: "#ea580c" },
       secondary: { key: "comments", label: "댓글", color: "#16a34a" }
     }
-  }
-];
+  };
+
+  return [youtubePlatform, redditPlatform];
+};
 
 /**
  * 플랫폼 옵션 배열 반환

--- a/src/utils/dashboard_utils.js
+++ b/src/utils/dashboard_utils.js
@@ -115,7 +115,7 @@ export const get_platform_data = (youtubeData) => {
     });
   }
 
-  const engagementRate = (totalLikes && totalViews) ? ((totalLikes / totalViews) * 100).toFixed(2) : "0.00";
+  const engagementRate = (totalLikes && totalViews) ? Math.min(100, ((totalLikes * 0.5 + totalComments * 0.8) / totalViews) * 100).toFixed(2) : "0.00";
 
   const youtubePlatform = {
     name: "YouTube",


### PR DESCRIPTION
package.json 업데이트
youtube 만 total  조회수, 좋아요, 참여율을 보여줍니다.
대시보드 페이지에 총댓글 추가, 참여율 보이는 위치 수정하였고 참여율은 설명또한 추가하였습니다.
기존에 total data 로 화면을 보여주었는데
date-fns 을 활용하여 현재 날짜 기준으로 7일 받아오도록
/api.../range로 수정


채널 ID를 볼수있는 API 요청 로직을 추가하였습니다. 
[ConnectYouTubeButton.jsx]
      │
      ├── fetchStatus()
      │     └── GET /api/google/status → 연결 확인
      │
      ├── (if connected)
      │     └── GET /api/youtube/channelId → 채널ID, Title 저장
      │
      └── startOAuth()
            └── GET /api/google/login-url → 팝업 열기
                   ↓
                 성공시 → fetchStatus() 재실행

