### PR TITLE
feat: YouTube 업로드 기능 구현 및 주요 버그 수정

### DIFF
--- a/src/common/api/api.js
+++ b/src/common/api/api.js
@@ -539,10 +539,9 @@ export async function uploadFileToS3(presignedUrl, file, contentType) {
  * @param {string} s3Key - S3 객체 키
  * @param {string} locationCode - 위치 코드
  * @param {string} promptText - 프롬프트 텍스트
- * @param {string} resultType - 미디어 타입 ('YOUTUBE' 또는 'REDDIT')
  * @returns {Promise} 확인 응답 데이터
  */
-export async function confirmImageUpload(s3Key, locationCode, promptText = "", resultType) {
+export async function confirmImageUpload(s3Key, locationCode, promptText = "") {
   if (!s3Key || !locationCode) {
     throw new Error('S3 키와 위치 코드가 필요합니다.');
   }
@@ -553,8 +552,7 @@ export async function confirmImageUpload(s3Key, locationCode, promptText = "", r
     body: JSON.stringify({
       key: s3Key,
       locationCode: locationCode,
-      prompt_text: promptText,
-      result_type: resultType
+      prompt_text: promptText
     })
   });
 
@@ -571,10 +569,9 @@ export async function confirmImageUpload(s3Key, locationCode, promptText = "", r
  * @param {File} file - 업로드할 파일
  * @param {string} locationCode - 위치 코드
  * @param {string} promptText - 프롬프트 텍스트
- * @param {string} resultType - 미디어 타입 ('YOUTUBE' 또는 'REDDIT')
  * @returns {Promise} 전체 업로드 프로세스 결과
  */
-export async function uploadImageToS3Complete(file, locationCode, promptText = "", resultType) {
+export async function uploadImageToS3Complete(file, locationCode, promptText = "") {
   try {
     // 1단계: Presigned URL 요청
     const presignData = await getS3PresignedUrl(file.type);
@@ -584,7 +581,7 @@ export async function uploadImageToS3Complete(file, locationCode, promptText = "
     await uploadFileToS3(url, file, contentType);
 
     // 3단계: 백엔드에 업로드 완료 알림
-    const confirmResult = await confirmImageUpload(key, locationCode, promptText, resultType);
+    const confirmResult = await confirmImageUpload(key, locationCode, promptText);
 
     return {
       success: true,

--- a/src/common/ui/PlatformSelector.jsx
+++ b/src/common/ui/PlatformSelector.jsx
@@ -1,0 +1,157 @@
+/**
+ * 플랫폼 선택 컴포넌트
+ * YouTube와 Reddit 플랫폼을 선택할 수 있는 재사용 가능한 UI 컴포넌트
+ */
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Play, Image } from 'lucide-react';
+
+/**
+ * 플랫폼 선택 컴포넌트
+ * @param {Object} props - 컴포넌트 props
+ * @param {string} props.selectedPlatform - 현재 선택된 플랫폼 ('youtube' | 'reddit')
+ * @param {Function} props.onPlatformChange - 플랫폼 변경 시 호출되는 콜백 함수
+ * @returns {JSX.Element} 플랫폼 선택 컴포넌트
+ */
+const PlatformSelector = ({ selectedPlatform, onPlatformChange }) => {
+  const platforms = [
+    {
+      id: 'youtube',
+      name: 'YouTube',
+      icon: Play,
+      color: 'from-red-500/20 to-red-600/20',
+      borderColor: 'border-red-500/30',
+      hoverColor: 'hover:from-red-500/30 hover:to-red-600/30',
+      textColor: 'text-red-600',
+      description: '동영상 생성'
+    },
+    {
+      id: 'reddit',
+      name: 'Reddit',
+      icon: Image,
+      color: 'from-orange-500/20 to-red-500/20',
+      borderColor: 'border-orange-500/30',
+      hoverColor: 'hover:from-orange-500/30 hover:to-red-500/30',
+      textColor: 'text-orange-600',
+      description: '이미지 생성'
+    }
+  ];
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 mb-4">
+        <div className="w-1 h-6 bg-gradient-to-b from-blue-500 to-purple-500 rounded-full"></div>
+        <h3 className="text-lg font-semibold text-gray-800 dark:text-white">
+          플랫폼 선택
+        </h3>
+      </div>
+      
+      <div className="grid grid-cols-2 gap-4">
+        {platforms.map((platform) => {
+          const Icon = platform.icon;
+          const isSelected = selectedPlatform === platform.id;
+          
+          return (
+            <motion.button
+              key={platform.id}
+              onClick={() => onPlatformChange(platform.id)}
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+              className={`
+                relative p-4 rounded-2xl border-2 transition-all duration-200
+                ${isSelected 
+                  ? `bg-gradient-to-br ${platform.color} ${platform.borderColor} shadow-lg` 
+                  : 'bg-white/50 dark:bg-gray-800/50 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
+                }
+                ${!isSelected && `${platform.hoverColor}`}
+              `}
+            >
+              {/* 선택된 상태 표시 */}
+              {isSelected && (
+                <motion.div
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  className="absolute -top-2 -right-2 w-6 h-6 bg-blue-500 rounded-full flex items-center justify-center shadow-lg"
+                >
+                  <div className="w-2 h-2 bg-white rounded-full"></div>
+                </motion.div>
+              )}
+              
+              <div className="flex flex-col items-center text-center space-y-3">
+                {/* 아이콘 */}
+                <div className={`
+                  p-3 rounded-xl
+                  ${isSelected 
+                    ? 'bg-white/30 dark:bg-white/20' 
+                    : 'bg-gray-100 dark:bg-gray-700'
+                  }
+                `}>
+                  <Icon className={`
+                    w-6 h-6
+                    ${isSelected 
+                      ? platform.textColor 
+                      : 'text-gray-600 dark:text-gray-400'
+                    }
+                  `} />
+                </div>
+                
+                {/* 플랫폼 이름 */}
+                <div>
+                  <h4 className={`
+                    font-bold text-base
+                    ${isSelected 
+                      ? 'text-gray-800 dark:text-white' 
+                      : 'text-gray-700 dark:text-gray-300'
+                    }
+                  `}>
+                    {platform.name}
+                  </h4>
+                  <p className={`
+                    text-xs mt-1
+                    ${isSelected 
+                      ? 'text-gray-600 dark:text-gray-300' 
+                      : 'text-gray-500 dark:text-gray-400'
+                    }
+                  `}>
+                    {platform.description}
+                  </p>
+                </div>
+              </div>
+              
+              {/* Reddit 준비 중 배지 */}
+              {platform.id === 'reddit' && (
+                <div className="absolute top-2 left-2">
+                  <span className="px-2 py-1 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 text-xs font-medium rounded-full">
+                    준비중
+                  </span>
+                </div>
+              )}
+            </motion.button>
+          );
+        })}
+      </div>
+      
+      {/* 선택된 플랫폼 안내 */}
+      {selectedPlatform && (
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mt-4 p-3 rounded-lg bg-blue-50/50 dark:bg-blue-900/20 border border-blue-200/30 dark:border-blue-700/30"
+        >
+          <p className="text-sm text-blue-700 dark:text-blue-300">
+            <span className="font-semibold">
+              {platforms.find(p => p.id === selectedPlatform)?.name}
+            </span>
+            {selectedPlatform === 'youtube' 
+              ? ' 플랫폼이 선택되었습니다. 아래 정보를 입력해주세요.'
+              : ' 플랫폼이 선택되었습니다. (현재 준비 중인 기능입니다)'
+            }
+          </p>
+        </motion.div>
+      )}
+    </div>
+  );
+};
+
+export default PlatformSelector;

--- a/src/common/ui/PlatformSelector.jsx
+++ b/src/common/ui/PlatformSelector.jsx
@@ -34,7 +34,8 @@ const PlatformSelector = ({ selectedPlatform, onPlatformChange }) => {
       borderColor: 'border-orange-500/30',
       hoverColor: 'hover:from-orange-500/30 hover:to-red-500/30',
       textColor: 'text-orange-600',
-      description: '이미지 생성'
+      description: '이미지 생성',
+      disabled: true
     }
   ];
 
@@ -55,16 +56,19 @@ const PlatformSelector = ({ selectedPlatform, onPlatformChange }) => {
           return (
             <motion.button
               key={platform.id}
-              onClick={() => onPlatformChange(platform.id)}
-              whileHover={{ scale: 1.02 }}
-              whileTap={{ scale: 0.98 }}
+              onClick={() => !platform.disabled && onPlatformChange(platform.id)}
+              whileHover={platform.disabled ? {} : { scale: 1.02 }}
+              whileTap={platform.disabled ? {} : { scale: 0.98 }}
+              disabled={platform.disabled}
               className={`
                 relative p-4 rounded-2xl border-2 transition-all duration-200
-                ${isSelected 
-                  ? `bg-gradient-to-br ${platform.color} ${platform.borderColor} shadow-lg` 
-                  : 'bg-white/50 dark:bg-gray-800/50 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
+                ${platform.disabled 
+                  ? 'bg-gray-100 dark:bg-gray-700/50 border-gray-300 dark:border-gray-600 cursor-not-allowed opacity-60'
+                  : isSelected 
+                    ? `bg-gradient-to-br ${platform.color} ${platform.borderColor} shadow-lg` 
+                    : 'bg-white/50 dark:bg-gray-800/50 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
                 }
-                ${!isSelected && `${platform.hoverColor}`}
+                ${!isSelected && !platform.disabled && `${platform.hoverColor}`}
               `}
             >
               {/* 선택된 상태 표시 */}

--- a/src/common/ui/notification.jsx
+++ b/src/common/ui/notification.jsx
@@ -10,6 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { Bell, CheckCircle2, Play, Trash2, Check } from 'lucide-react';
 import { useOnClickOutside } from '@/common/hooks/use-on-click-outside';
 import { useNotificationStore } from '@/features/real-time-notifications/logic/notification-store';
+import { formatToKST } from '@/common/utils/date-utils';
 
 /**
  * Premium Notification 컴포넌트
@@ -85,15 +86,7 @@ const Notification = () => {
   // 외부 클릭 감지
   useOnClickOutside(dropdownRef, closeDropdown);
 
-  // UTC 타임스탬프를 KST '오전/오후 HH:MM' 형식으로 변환
-  const formatToKST = useCallback((utcTimestamp) => {
-    return new Date(utcTimestamp).toLocaleString('ko-KR', {
-      timeZone: 'Asia/Seoul',
-      hour12: true,
-      hour: '2-digit',
-      minute: '2-digit'
-    });
-  }, []);
+  // formatToKST는 이제 date-utils에서 import하여 사용
 
   // 알림 타입별 아이콘 매핑
   const getNotificationIcon = (type) => {

--- a/src/common/ui/notification.jsx
+++ b/src/common/ui/notification.jsx
@@ -6,6 +6,7 @@
 import React, { useState, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
 import { Bell, CheckCircle2, Play, Trash2, Check } from 'lucide-react';
 import { useOnClickOutside } from '@/common/hooks/use-on-click-outside';
 import { useNotificationStore } from '@/features/real-time-notifications/logic/notification-store';
@@ -19,6 +20,9 @@ const Notification = () => {
   const [dropdownPosition, setDropdownPosition] = useState({ top: 0, left: 0 });
   const buttonRef = useRef(null);
   const dropdownRef = useRef(null);
+
+  // React Router 내비게이션 훅
+  const navigate = useNavigate();
 
   // Zustand 스토어에서 알림 데이터 가져오기
   const { 
@@ -53,12 +57,19 @@ const Notification = () => {
     setIsOpen(false);
   }, []);
 
-  // 알림 클릭 핸들러
+  // 알림 클릭 핸들러 (네비게이션 기능 추가)
   const handleNotificationClick = useCallback((notification) => {
+    // 읽지 않은 알림을 읽음 상태로 변경
     if (!notification.read) {
       mark_as_read(notification.id);
     }
-  }, [mark_as_read]);
+    
+    // 알림에 path 속성이 있으면 해당 경로로 이동
+    if (notification.path) {
+      navigate(notification.path);
+      setIsOpen(false); // 드롭다운 닫기
+    }
+  }, [mark_as_read, navigate]);
 
   // 모든 알림 읽음 처리
   const handleMarkAllRead = useCallback(() => {

--- a/src/common/utils/date-utils.js
+++ b/src/common/utils/date-utils.js
@@ -1,0 +1,166 @@
+/**
+ * 날짜 처리 유틸리티 함수들
+ * 프로젝트 전체에서 일관된 날짜 형식을 제공하기 위한 통합 유틸리티
+ */
+
+/**
+ * 날짜를 yy-mm-dd hh:mm 형식으로 포맷팅하는 함수
+ * @param {string|Date} dateString - ISO 문자열 또는 Date 객체
+ * @returns {string} yy-mm-dd hh:mm 형식의 날짜 문자열
+ */
+export function formatDateTime(dateString) {
+  try {
+    const date = new Date(dateString);
+    
+    // 유효한 날짜인지 확인
+    if (isNaN(date.getTime())) {
+      return formatDateTime(new Date()); // 현재 시간으로 대체
+    }
+    
+    // yy-mm-dd hh:mm 형식으로 포맷팅
+    const year = String(date.getFullYear()).slice(-2);
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    
+    return `${year}-${month}-${day} ${hours}:${minutes}`;
+  } catch (error) {
+    console.error('날짜 포맷팅 실패:', error);
+    return formatDateTime(new Date()); // 현재 시간으로 대체
+  }
+}
+
+/**
+ * UTC 타임스탬프를 KST '오전/오후 HH:MM' 형식으로 변환
+ * @param {string|Date} utcTimestamp - UTC 타임스탬프
+ * @returns {string} KST 시간 문자열 (예: "오후 02:30")
+ */
+export function formatToKST(utcTimestamp) {
+  try {
+    const date = new Date(utcTimestamp);
+    
+    // 유효한 날짜인지 확인
+    if (isNaN(date.getTime())) {
+      return formatToKST(new Date()); // 현재 시간으로 대체
+    }
+    
+    return date.toLocaleString('ko-KR', {
+      timeZone: 'Asia/Seoul',
+      hour12: true,
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+  } catch (error) {
+    console.error('KST 시간 포맷팅 실패:', error);
+    return formatToKST(new Date()); // 현재 시간으로 대체
+  }
+}
+
+/**
+ * 생성 시간을 HH:MM 형식으로 포맷팅하는 함수
+ * @param {string|Date} creationTime - 생성 시간
+ * @returns {string} HH:MM 형식의 시간 문자열
+ */
+export function formatCreationTime(creationTime) {
+  try {
+    if (!creationTime) return '';
+    
+    const date = new Date(creationTime);
+    
+    // 유효한 날짜인지 확인
+    if (isNaN(date.getTime())) {
+      return formatCreationTime(new Date()); // 현재 시간으로 대체
+    }
+    
+    return date.toLocaleString('ko-KR', {
+      timeZone: 'Asia/Seoul',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    });
+  } catch (error) {
+    console.error('생성 시간 포맷팅 실패:', error);
+    return formatCreationTime(new Date()); // 현재 시간으로 대체
+  }
+}
+
+/**
+ * 날짜 객체가 유효한지 확인하는 헬퍼 함수
+ * @param {string|Date} dateInput - 확인할 날짜 입력값
+ * @returns {boolean} 유효한 날짜인지 여부
+ */
+export function isValidDate(dateInput) {
+  try {
+    const date = new Date(dateInput);
+    return !isNaN(date.getTime());
+  } catch (error) {
+    return false;
+  }
+}
+
+/**
+ * 현재 시간을 ISO 문자열로 반환하는 헬퍼 함수
+ * @returns {string} ISO 형식의 현재 시간 문자열
+ */
+export function getCurrentISOString() {
+  return new Date().toISOString();
+}
+
+/**
+ * 두 날짜 간의 차이를 분 단위로 계산하는 함수
+ * @param {string|Date} startDate - 시작 날짜
+ * @param {string|Date} endDate - 종료 날짜 (기본값: 현재 시간)
+ * @returns {number} 분 단위 차이
+ */
+export function getMinutesDifference(startDate, endDate = new Date()) {
+  try {
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+      return 0;
+    }
+    
+    return Math.floor((end.getTime() - start.getTime()) / (1000 * 60));
+  } catch (error) {
+    console.error('시간 차이 계산 실패:', error);
+    return 0;
+  }
+}
+
+/**
+ * 상대적 시간 표시 (예: "5분 전", "2시간 전")
+ * @param {string|Date} dateInput - 비교할 날짜
+ * @returns {string} 상대적 시간 문자열
+ */
+export function getRelativeTime(dateInput) {
+  try {
+    const date = new Date(dateInput);
+    if (isNaN(date.getTime())) {
+      return '알 수 없음';
+    }
+    
+    const now = new Date();
+    const diffInMinutes = getMinutesDifference(date, now);
+    
+    if (diffInMinutes < 1) return '방금 전';
+    if (diffInMinutes < 60) return `${diffInMinutes}분 전`;
+    
+    const diffInHours = Math.floor(diffInMinutes / 60);
+    if (diffInHours < 24) return `${diffInHours}시간 전`;
+    
+    const diffInDays = Math.floor(diffInHours / 24);
+    if (diffInDays < 7) return `${diffInDays}일 전`;
+    
+    const diffInWeeks = Math.floor(diffInDays / 7);
+    if (diffInWeeks < 4) return `${diffInWeeks}주 전`;
+    
+    const diffInMonths = Math.floor(diffInDays / 30);
+    return `${diffInMonths}개월 전`;
+    
+  } catch (error) {
+    console.error('상대 시간 계산 실패:', error);
+    return '알 수 없음';
+  }
+}

--- a/src/containers/VideoStreamTestPanel/index.jsx
+++ b/src/containers/VideoStreamTestPanel/index.jsx
@@ -5,7 +5,7 @@
 
 import React, { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Play, Download, Loader2, AlertCircle, TestTube } from 'lucide-react';
+import { Play, Download, Loader2, AlertCircle, TestTube, Upload } from 'lucide-react';
 import { Button } from '@/common/ui/button';
 import { getVideoStreamUrl, getVideoDownloadUrl } from '@/common/api/api';
 
@@ -13,15 +13,20 @@ import { getVideoStreamUrl, getVideoDownloadUrl } from '@/common/api/api';
  * VideoStreamTestPanel 컴포넌트
  * @param {Object} props - 컴포넌트 props
  * @param {boolean} props.dark_mode - 다크모드 여부
+ * @param {Function} props.on_upload_test - YouTube 업로드 테스트 핸들러
  * @returns {JSX.Element} VideoStreamTestPanel 컴포넌트
  */
-const VideoStreamTestPanel = ({ dark_mode }) => {
+const VideoStreamTestPanel = ({ dark_mode, on_upload_test }) => {
   // 상태 관리
   const [resultId, setResultId] = useState('81');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [videoUrl, setVideoUrl] = useState(null);
   const [successMessage, setSuccessMessage] = useState(null);
+  
+  // YouTube 업로드 테스트용 상태
+  const [jobId, setJobId] = useState('test-job-001');
+  const [uploadResultId, setUploadResultId] = useState('81');
 
   // 에러 메시지 초기화
   const clearMessages = () => {
@@ -80,6 +85,21 @@ const VideoStreamTestPanel = ({ dark_mode }) => {
   const handleResultIdChange = (e) => {
     setResultId(e.target.value);
     clearMessages();
+  };
+  
+  // YouTube 업로드 테스트 핸들러
+  const handleUploadTest = () => {
+    if (!jobId.trim() || !uploadResultId.trim()) {
+      setError('업로드 테스트를 위해 jobId와 resultId를 모두 입력해주세요.');
+      return;
+    }
+    
+    if (on_upload_test) {
+      on_upload_test(jobId, uploadResultId);
+      setSuccessMessage(`업로드 테스트 모달을 열었습니다. (Job: ${jobId}, Result: ${uploadResultId})`);
+    } else {
+      setError('업로드 테스트 핸들러가 설정되지 않았습니다.');
+    }
   };
 
   return (
@@ -212,6 +232,84 @@ const VideoStreamTestPanel = ({ dark_mode }) => {
           </div>
         </motion.div>
       )}
+
+      {/* YouTube 업로드 테스트 섹션 */}
+      <div className="mt-8 pt-6 border-t border-gray-200/50 dark:border-gray-700/50">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="p-2 rounded-lg bg-gradient-to-r from-red-500/20 to-pink-500/20">
+            <Upload className="w-5 h-5 text-red-600 dark:text-red-400" />
+          </div>
+          <div>
+            <h3 className={`text-lg font-semibold ${dark_mode ? 'text-white' : 'text-gray-900'}`}>
+              YouTube 업로드 테스트
+            </h3>
+            <p className={`text-sm ${dark_mode ? 'text-gray-400' : 'text-gray-600'}`}>
+              jobId와 resultId로 직접 업로드 모달 열기
+            </p>
+          </div>
+        </div>
+
+        {/* YouTube 테스트 입력 및 컨트롤 영역 */}
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-4">
+          {/* JobID 입력 */}
+          <div>
+            <label className={`block text-sm font-medium mb-2 ${
+              dark_mode ? 'text-gray-300' : 'text-gray-700'
+            }`}>
+              Job ID
+            </label>
+            <input
+              type="text"
+              value={jobId}
+              onChange={(e) => {
+                setJobId(e.target.value);
+                clearMessages();
+              }}
+              className={`w-full px-3 py-2 rounded-lg border transition-colors ${
+                dark_mode 
+                  ? 'bg-gray-700/50 border-gray-600 text-white focus:border-red-400' 
+                  : 'bg-white border-gray-300 text-gray-900 focus:border-red-500'
+              } focus:outline-none focus:ring-2 focus:ring-red-500/20`}
+              placeholder="예: test-job-001"
+            />
+          </div>
+          
+          {/* Upload ResultID 입력 */}
+          <div>
+            <label className={`block text-sm font-medium mb-2 ${
+              dark_mode ? 'text-gray-300' : 'text-gray-700'
+            }`}>
+              Result ID
+            </label>
+            <input
+              type="text"
+              value={uploadResultId}
+              onChange={(e) => {
+                setUploadResultId(e.target.value);
+                clearMessages();
+              }}
+              className={`w-full px-3 py-2 rounded-lg border transition-colors ${
+                dark_mode 
+                  ? 'bg-gray-700/50 border-gray-600 text-white focus:border-red-400' 
+                  : 'bg-white border-gray-300 text-gray-900 focus:border-red-500'
+              } focus:outline-none focus:ring-2 focus:ring-red-500/20`}
+              placeholder="예: 81"
+            />
+          </div>
+
+          {/* 업로드 테스트 버튼 */}
+          <div className="lg:col-span-2 flex items-end">
+            <Button
+              onClick={handleUploadTest}
+              disabled={!jobId.trim() || !uploadResultId.trim()}
+              className="w-full bg-gradient-to-r from-red-500/20 to-pink-500/20 border border-red-500/30 hover:from-red-500/30 hover:to-pink-500/30 text-gray-800 dark:text-white rounded-lg"
+            >
+              <Upload className="w-4 h-4 mr-2" />
+              업로드 테스트 모달 열기
+            </Button>
+          </div>
+        </div>
+      </div>
 
       {/* 로딩 오버레이 */}
       {isLoading && (

--- a/src/features/ai-media-request/logic/use-media-request-form.js
+++ b/src/features/ai-media-request/logic/use-media-request-form.js
@@ -5,7 +5,8 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { use_content_launch } from '@/features/content-management/logic/use-content-launch';
-import { apiFetch } from '@/common/api/api';
+import { uploadImageToS3Complete } from '@/common/api/api';
+import { useNotificationStore } from '@/features/real-time-notifications/logic/notification-store';
 
 /**
  * useMediaRequestForm 커스텀 훅
@@ -97,7 +98,7 @@ export const useMediaRequestForm = (on_close, isPriority = false, selectedVideoD
     }
   }, [selectedVideoData, reset_form]);
 
-  // 폼 제출 핸들러
+  // 폼 제출 핸들러 (낙관적 UI 패턴 적용)
   const handle_submit = useCallback(async () => {
     // 필수 항목 검증
     if (!selected_location) {
@@ -113,21 +114,7 @@ export const useMediaRequestForm = (on_close, isPriority = false, selectedVideoD
     set_is_submitting(true);
 
     try {
-      // 백엔드 전송 데이터 구성
-      const form_data = new FormData();
-      form_data.append('location_id', selected_location.poi_id);
-      
-      // 프롬프트가 있을 때만 user_request에 포함
-      if (prompt_text && prompt_text.trim()) {
-        form_data.append('user_request', JSON.stringify({ prompt: prompt_text.trim() }));
-      } else {
-        // 프롬프트 없을 시에는 빈 객체 전송
-        form_data.append('user_request', JSON.stringify({}));
-      }
-      
-      form_data.append('reference_image', uploaded_file);
-
-      // 이미지를 Base64로 변환
+      // 이미지를 Base64로 변환 (UI 표시용)
       const convert_to_base64 = (file) => {
         return new Promise((resolve, reject) => {
           const reader = new FileReader();
@@ -154,15 +141,14 @@ export const useMediaRequestForm = (on_close, isPriority = false, selectedVideoD
       // 마지막 요청 정보를 localStorage에 저장 (자동 생성용)
       const last_request_info = {
         location: selected_location,
-        image_url: image_url, // base64 이미지 URL 저장 (파일 객체 대신)
+        image_url: image_url,
         prompt: prompt_text && prompt_text.trim() ? prompt_text.trim() : null,
         timestamp: new Date().toISOString()
       };
       localStorage.setItem('last_video_request', JSON.stringify(last_request_info));
       
-      // on_request_success 콜백이 있으면 호출, 없으면 기존 로직 사용
+      // 🚀 낙관적 UI: on_request_success 콜백을 즉시 실행하여 UI가 먼저 반응
       if (on_request_success) {
-        // 새로운 방식: 성공 콜백으로 데이터 전달
         on_request_success({
           video_data,
           creation_date,
@@ -175,77 +161,43 @@ export const useMediaRequestForm = (on_close, isPriority = false, selectedVideoD
         } else {
           use_content_launch.getState().add_pending_video(video_data, creation_date);
         }
-      }
-      
-      // S3 Presigned URL을 이용한 2단계 업로드
-      // 1단계: 백엔드에서 presigned URL 가져오기
-// 1) presign 호출
-const presignRes = await apiFetch('/api/images/presign', {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' }, // Authorization은 apiFetch가 자동 추가
-  body: JSON.stringify({ contentType: uploaded_file.type })
-});
-
-if (!presignRes.ok) {
-  const errText = await presignRes.text().catch(() => '');
-  throw new Error(`Presigned URL 요청 실패: ${presignRes.status} ${errText}`);
-}
-
-// 2) presign 결과 파싱 + 로그
-const presign = await presignRes.json(); // { url, key, contentType }
-const { url, key, contentType } = presign;
-
-// 보안상 쿼리(서명) 없이 경로만 보고 싶으면:
-try {
-  const u = new URL(url);
-} catch { /* url 파싱 실패해도 무시 */ }
-
-// 표로 깔끔하게 보고 싶으면:
-
-
-      // 2단계: S3에 직접 파일 업로드
-const uploadRes = await fetch(url, {
-  method: 'PUT',
-  headers: { 'Content-Type': contentType }, // presign에 사용한 값과 완전히 동일!
-  body: uploaded_file
-});
-
-if (!uploadRes.ok) {
-  const errText = await uploadRes.text().catch(() => '');
-  throw new Error(`S3 업로드 실패: ${uploadRes.status} ${errText}`);
-}
-
-      // 3단계: 백엔드에 업로드 완료 알림
-const notifyRes = await apiFetch('/api/images/confirm', {
-  method: 'POST', // ✅ 서버는 POST로 받음
-  headers: { 'Content-Type': 'application/json' }, // Authorization은 apiFetch가 자동 추가
-  body: JSON.stringify({
-    key, // presign에서 받은 key 그대로
-    locationCode: selected_location.poi_id,
-    prompt_text: prompt_text && prompt_text.trim() ? prompt_text.trim() : ""
-  })
-});
-
-if (!notifyRes.ok) {
-  const errText = await notifyRes.text().catch(() => '');
-  throw new Error(`업로드 완료 알림 실패: ${notifyRes.status} ${errText}`);
-}
-
-const confirmJson = await notifyRes.json().catch(() => ({}));
-
-      // 성공 처리
-      if (!on_request_success) {
-        // 기존 방식: 직접 성공 모달 표시
+        
+        // 기존 방식에서도 성공 모달 즉시 표시
         set_is_success_modal_open(true);
       }
+      
+      // 폼 초기화
       reset_form();
+      
+      // 🔄 백그라운드 처리: S3 업로드를 비동기로 실행
+      (async () => {
+        try {
+          // S3 통합 업로드 함수 사용
+          await uploadImageToS3Complete(
+            uploaded_file,
+            selected_location.poi_id,
+            prompt_text && prompt_text.trim() ? prompt_text.trim() : ""
+          );
+          
+        } catch (background_error) {
+          // 백그라운드 작업 실패 시 사용자에게 알림
+          useNotificationStore.getState().add_notification({
+            type: 'error',
+            message: `미디어 업로드 중 오류가 발생했습니다: ${background_error.message}`,
+            data: { error: background_error.message }
+          });
+          
+          // TODO: 미래 구현 예정 - 실패 상태로 비디오 전환
+          // use_content_launch.getState().transition_to_failed(video_data.temp_id);
+        }
+      })();
       
     } catch (error) {
       alert('요청 전송에 실패했습니다. 다시 시도해주세요.');
     } finally {
       set_is_submitting(false);
     }
-  }, [selected_location, uploaded_file, prompt_text, reset_form]);
+  }, [selected_location, uploaded_file, prompt_text, reset_form, on_request_success, isPriority]);
 
   // 폼 검증 상태
   const is_form_valid = selected_location && uploaded_file && !is_submitting;

--- a/src/features/ai-media-request/logic/use-media-request-form.js
+++ b/src/features/ai-media-request/logic/use-media-request-form.js
@@ -129,8 +129,10 @@ export const useMediaRequestForm = (on_close, isPriority = false, selectedVideoD
       // 현재 날짜 생성 (YYYY-MM-DD 형식)
       const creation_date = new Date().toISOString().split('T')[0];
       
-      // 영상 데이터 구성
+      // 영상 데이터 구성 (temp_id 명시적 생성)
+      const video_temp_id = `temp-${Date.now()}`;
       const video_data = {
+        temp_id: video_temp_id,
         title: `${selected_location.name} AI 영상`,
         location_id: selected_location.poi_id,
         location_name: selected_location.name,
@@ -180,15 +182,19 @@ export const useMediaRequestForm = (on_close, isPriority = false, selectedVideoD
           );
           
         } catch (background_error) {
-          // 백그라운드 작업 실패 시 사용자에게 알림
+          // 백그라운드 작업 실패 시 영상을 실패 상태로 전환
+          use_content_launch.getState().transition_to_failed(video_temp_id);
+          
+          // 사용자에게 실패 알림
           useNotificationStore.getState().add_notification({
             type: 'error',
-            message: `미디어 업로드 중 오류가 발생했습니다: ${background_error.message}`,
-            data: { error: background_error.message }
+            message: `영상 업로드에 실패했습니다: ${background_error.message}`,
+            data: { 
+              error: background_error.message,
+              temp_id: video_temp_id,
+              failed_at: new Date().toISOString()
+            }
           });
-          
-          // TODO: 미래 구현 예정 - 실패 상태로 비디오 전환
-          // use_content_launch.getState().transition_to_failed(video_data.temp_id);
         }
       })();
       

--- a/src/features/ai-media-request/logic/use-media-request-form.js
+++ b/src/features/ai-media-request/logic/use-media-request-form.js
@@ -179,7 +179,7 @@ export const useMediaRequestForm = (on_close, isPriority = false, selectedVideoD
             uploaded_file,
             selected_location.poi_id,
             prompt_text && prompt_text.trim() ? prompt_text.trim() : "",
-            "YOUTUBE"
+            // "YOUTUBE"
           );
           
         } catch (background_error) {

--- a/src/features/ai-media-request/ui/AiMediaRequestModal.jsx
+++ b/src/features/ai-media-request/ui/AiMediaRequestModal.jsx
@@ -46,6 +46,10 @@ const AIMediaRequestModal = ({ is_open, on_close, isPriority = false, selectedVi
 
   // 플랫폼 변경 핸들러
   const handlePlatformChange = useCallback((platform) => {
+    // Reddit 플랫폼 선택 방지
+    if (platform === 'reddit') {
+      return;
+    }
     setSelectedPlatform(platform);
   }, []);
 
@@ -175,15 +179,12 @@ const AIMediaRequestModal = ({ is_open, on_close, isPriority = false, selectedVi
             {selectedPlatform === 'reddit' && (
               <Button
                 onClick={() => {
-                  const redditSubmitButton = document.getElementById('reddit-form-submit');
-                  if (redditSubmitButton) {
-                    redditSubmitButton.click();
-                  }
+                  // Reddit 기능 비활성화로 인해 아무 동작 안함
                 }}
-                disabled={false} // Reddit 폼 유효성은 내부에서 처리
+                disabled={true} // 항상 비활성화
                 className="bg-gradient-to-r from-orange-500/20 to-red-500/20 border border-orange-500/30 hover:from-orange-500/30 hover:to-red-500/30 text-gray-800 dark:text-white disabled:opacity-50 font-semibold"
               >
-                이미지 생성 요청 (준비중)
+                이미지 생성 (준비 중)
               </Button>
             )}
           </div>

--- a/src/features/ai-media-request/ui/AiMediaRequestModal.jsx
+++ b/src/features/ai-media-request/ui/AiMediaRequestModal.jsx
@@ -1,17 +1,19 @@
 /**
- * AI 미디어 제작 요청 모달 컴포넌트 (리팩토링됨)
- * 재사용 가능한 컴포넌트들로 구성되어 더 나은 유지보수성과 재사용성을 제공
+ * AI 미디어 제작 요청 모달 컴포넌트 (플랫폼 지원 확장)
+ * YouTube와 Reddit 플랫폼을 지원하는 통합 미디어 제작 요청 모달
  */
 
-import React, { useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X } from 'lucide-react';
 import { Button } from '@/common/ui/button';
 import SuccessModal from '@/common/ui/success-modal';
+import PlatformSelector from '@/common/ui/PlatformSelector';
 import LocationSelector from '@/common/ui/location-selector';
 import ImageUploader from '@/common/ui/image-uploader';
 import NaturalPromptInput from '@/common/ui/natural-prompt-input';
+import RedditRequestForm from '@/features/reddit-media-request/ui/RedditRequestForm';
 import { useMediaRequestForm } from '@/features/ai-media-request/logic/use-media-request-form';
 
 /**
@@ -24,7 +26,10 @@ import { useMediaRequestForm } from '@/features/ai-media-request/logic/use-media
  * @returns {JSX.Element} AI 미디어 제작 요청 모달 컴포넌트
  */
 const AIMediaRequestModal = ({ is_open, on_close, isPriority = false, selectedVideoData = null, on_request_success = null }) => {
-  // 폼 상태 관리 커스텀 훅 사용
+  // 플랫폼 선택 상태
+  const [selectedPlatform, setSelectedPlatform] = useState('youtube');
+
+  // YouTube 폼 상태 관리 커스텀 훅 사용
   const {
     selected_location,
     uploaded_file,
@@ -39,9 +44,15 @@ const AIMediaRequestModal = ({ is_open, on_close, isPriority = false, selectedVi
     handle_success_modal_close
   } = useMediaRequestForm(on_close, isPriority, selectedVideoData, on_request_success);
 
+  // 플랫폼 변경 핸들러
+  const handlePlatformChange = useCallback((platform) => {
+    setSelectedPlatform(platform);
+  }, []);
+
   // 모달 닫기 핸들러
   const handle_close = useCallback(() => {
     if (is_submitting) return;
+    setSelectedPlatform('youtube'); // 플랫폼 초기화
     on_close();
   }, [is_submitting, on_close]);
 
@@ -100,23 +111,43 @@ const AIMediaRequestModal = ({ is_open, on_close, isPriority = false, selectedVi
 
           {/* 컨텐츠 */}
           <div className="p-6 space-y-5 max-h-[calc(95vh-140px)] overflow-y-auto">
-            {/* 위치 선택 컴포넌트 */}
-            <LocationSelector
-              selected_location={selected_location}
-              on_location_select={handle_location_select}
+            {/* 플랫폼 선택 컴포넌트 */}
+            <PlatformSelector
+              selectedPlatform={selectedPlatform}
+              onPlatformChange={handlePlatformChange}
             />
 
-            {/* 이미지 업로드 컴포넌트 */}
-            <ImageUploader
-              uploaded_file={uploaded_file}
-              on_file_change={handle_file_change}
-            />
+            {/* 플랫폼별 조건부 폼 렌더링 */}
+            {selectedPlatform === 'youtube' && (
+              <>
+                {/* YouTube 폼 - 기존 컴포넌트들 */}
+                <LocationSelector
+                  selected_location={selected_location}
+                  on_location_select={handle_location_select}
+                />
 
-            {/* 자연어 프롬프트 입력 컴포넌트 */}
-            <NaturalPromptInput
-              prompt_text={prompt_text}
-              on_prompt_change={handle_prompt_change}
-            />
+                <ImageUploader
+                  uploaded_file={uploaded_file}
+                  on_file_change={handle_file_change}
+                />
+
+                <NaturalPromptInput
+                  prompt_text={prompt_text}
+                  on_prompt_change={handle_prompt_change}
+                />
+              </>
+            )}
+
+            {selectedPlatform === 'reddit' && (
+              <>
+                {/* Reddit 폼 - 새로운 컴포넌트 */}
+                <RedditRequestForm
+                  onRequestSuccess={on_request_success}
+                  selectedVideoData={selectedVideoData}
+                  isPriority={isPriority}
+                />
+              </>
+            )}
           </div>
 
           {/* 푸터 */}
@@ -129,13 +160,32 @@ const AIMediaRequestModal = ({ is_open, on_close, isPriority = false, selectedVi
               취소
             </Button>
             
-            <Button
-              onClick={handle_submit}
-              disabled={!is_form_valid}
-              className="bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-500/30 hover:from-blue-500/30 hover:to-purple-500/30 text-gray-800 dark:text-white disabled:opacity-50 font-semibold"
-            >
-              {is_submitting ? '요청 중...' : '제작 요청하기'}
-            </Button>
+            {/* YouTube 제출 버튼 */}
+            {selectedPlatform === 'youtube' && (
+              <Button
+                onClick={handle_submit}
+                disabled={!is_form_valid}
+                className="bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-500/30 hover:from-blue-500/30 hover:to-purple-500/30 text-gray-800 dark:text-white disabled:opacity-50 font-semibold"
+              >
+                {is_submitting ? '요청 중...' : '동영상 생성 요청'}
+              </Button>
+            )}
+
+            {/* Reddit 제출 버튼 */}
+            {selectedPlatform === 'reddit' && (
+              <Button
+                onClick={() => {
+                  const redditSubmitButton = document.getElementById('reddit-form-submit');
+                  if (redditSubmitButton) {
+                    redditSubmitButton.click();
+                  }
+                }}
+                disabled={false} // Reddit 폼 유효성은 내부에서 처리
+                className="bg-gradient-to-r from-orange-500/20 to-red-500/20 border border-orange-500/30 hover:from-orange-500/30 hover:to-red-500/30 text-gray-800 dark:text-white disabled:opacity-50 font-semibold"
+              >
+                이미지 생성 요청 (준비중)
+              </Button>
+            )}
           </div>
         </motion.div>
       </motion.div>

--- a/src/features/content-management/lib/content-launch-utils.jsx
+++ b/src/features/content-management/lib/content-launch-utils.jsx
@@ -12,7 +12,8 @@ import {
   Upload, 
   Clock, 
   Loader2,
-  Globe
+  Globe,
+  AlertTriangle
 } from 'lucide-react';
 
 /**
@@ -59,7 +60,7 @@ export const get_platform_icon = (platform) => {
 
 /**
  * 상태에 따른 아이콘 반환
- * @param {string} status - 상태 ('ready', 'uploading', 'uploaded')
+ * @param {string} status - 상태 ('ready', 'uploading', 'uploaded', 'failed')
  * @param {string} item_id - 아이템 ID
  * @param {Array} uploading_items - 업로드 중인 아이템 목록
  * @returns {JSX.Element} 아이콘 컴포넌트
@@ -72,6 +73,7 @@ export const get_status_icon = (status, item_id, uploading_items = []) => {
   switch (status) {
     case 'uploaded': return <CheckCircle2 className="h-4 w-4 text-green-500" />;
     case 'ready': return <Upload className="h-4 w-4 text-blue-500" />;
+    case 'failed': return <AlertTriangle className="h-4 w-4 text-red-500" />;
     default: return <Clock className="h-4 w-4 text-yellow-500" />;
   }
 };
@@ -86,6 +88,7 @@ export const get_status_tooltip = (status) => {
     case 'ready': return '론칭 준비됨';
     case 'uploading': return '업로드 중';
     case 'uploaded': return '업로드 완료';
+    case 'failed': return '생성 실패';
     default: return '상태 불명';
   }
 };

--- a/src/features/content-management/logic/use-content-launch.js
+++ b/src/features/content-management/logic/use-content-launch.js
@@ -375,6 +375,27 @@ export const use_content_launch = create(
       },
       
       /**
+       * 영상을 '실패' 상태로 전환하는 함수
+       * @param {string} temp_id - 임시 ID
+       */
+      transition_to_failed: (temp_id) => {
+        set((state) => ({
+          pending_videos: state.pending_videos.map(video => 
+            video.temp_id === temp_id 
+              ? { 
+                  ...video, 
+                  status: 'failed',
+                  failed_at: new Date().toISOString()
+                }
+              : video
+          )
+        }));
+        
+        // 상태 업데이트 후 폴더 목록 갱신
+        get().fetch_folders();
+      },
+      
+      /**
        * 백엔드에 완료 알림 및 다음 영상 자동 생성 요청
        * @param {string} temp_id - 완료된 영상의 임시 ID
        */

--- a/src/features/content-management/ui/ContentItemCard.jsx
+++ b/src/features/content-management/ui/ContentItemCard.jsx
@@ -17,6 +17,7 @@ import {
   get_status_icon, 
   get_status_tooltip 
 } from '@/features/content-management/lib/content-launch-utils';
+import { formatCreationTime } from '@/common/utils/date-utils';
 
 /**
  * ContentItemCard 컴포넌트
@@ -48,17 +49,7 @@ const ContentItemCard = ({
   // 미리보기 클릭 가능한 상태인지 확인 (완성된 영상만)
   const is_clickable_for_preview = item.status === 'ready';
   
-  // creationTime 포매팅 함수
-  const formatCreationTime = (creationTime) => {
-    if (!creationTime) return '';
-    const date = new Date(creationTime);
-    return date.toLocaleString('ko-KR', {
-      timeZone: 'Asia/Seoul',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false
-    });
-  };
+  // formatCreationTime은 이제 date-utils에서 import하여 사용
   
   // console.log('ContentItemCard render:', {
   //   title: item.title,

--- a/src/features/content-management/ui/ContentItemCard.jsx
+++ b/src/features/content-management/ui/ContentItemCard.jsx
@@ -8,7 +8,7 @@ import { Card, CardContent } from '@/common/ui/card';
 import { Button } from '@/common/ui/button';
 import { Badge } from '@/common/ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/common/ui/tooltip';
-import { Clock, Upload, CheckCircle2, Loader2, Check } from 'lucide-react';
+import { Clock, Upload, CheckCircle2, Loader2, Check, AlertTriangle } from 'lucide-react';
 import Timer from '@/common/ui/timer';
 import jumpCatGif from '@/assets/images/Jumpcat/jump_cat.gif';
 import { 
@@ -255,6 +255,36 @@ const ContentItemCard = ({
             >
               <CheckCircle2 className="h-4 w-4 mr-2" />
               업로드 완료
+            </Button>
+          )}
+          
+          {/* 실패 상태 - 재시도 버튼 */}
+          {item.status === 'failed' && (
+            <Button
+              onClick={(e) => {
+                e.stopPropagation();
+                // 재시도 로직: localStorage에서 마지막 요청 정보를 가져와서 다시 실행
+                const handleRetry = () => {
+                  try {
+                    const lastRequestData = localStorage.getItem('last_video_request');
+                    if (lastRequestData) {
+                      const lastRequest = JSON.parse(lastRequestData);
+                      // 같은 설정으로 새 요청 생성을 위해 페이지 새로고침 유도
+                      // 실제 구현에서는 모달을 다시 열거나 직접 API 호출 가능
+                      alert(`마지막 요청 정보:\n위치: ${lastRequest.location?.name}\n프롬프트: ${lastRequest.prompt || '없음'}\n\n재시도하려면 새로운 미디어 제작 요청을 해주세요.`);
+                    } else {
+                      alert('재시도할 요청 정보를 찾을 수 없습니다. 새로운 미디어 제작 요청을 해주세요.');
+                    }
+                  } catch (error) {
+                    alert('재시도 중 오류가 발생했습니다. 새로운 미디어 제작 요청을 해주세요.');
+                  }
+                };
+                handleRetry();
+              }}
+              className="w-full bg-gradient-to-r from-red-500/20 to-orange-500/20 border border-red-500/30 hover:from-red-500/30 hover:to-orange-500/30 text-red-600 dark:text-red-400 rounded-xl transition-all duration-300 font-medium shadow-sm hover:shadow-md"
+            >
+              <AlertTriangle className="h-4 w-4 mr-2" />
+              재시도
             </Button>
           )}
         </div>

--- a/src/features/content-management/ui/ContentLaunchView.jsx
+++ b/src/features/content-management/ui/ContentLaunchView.jsx
@@ -67,10 +67,14 @@ const ContentLaunchView = ({ dark_mode }) => {
     fetch_folders();
   }, [fetch_folders]);
 
-  // 요청 성공 핸들러
+  // 요청 성공 핸들러 (낙관적 UI 패턴 적용)
   const handleRequestSuccess = (requestData) => {
+    // 기존 로직: 성공 모달 및 펜딩 비디오 데이터 설정
     set_pending_video_data(requestData);
     set_is_success_modal_open(true);
+    
+    // 🚀 낙관적 UI: AI 미디어 요청 모달을 즉시 닫기
+    set_is_request_modal_open(false);
   };
   
   // 성공 모달 닫기 핸들러 - 실제 비디오 카드 추가

--- a/src/features/content-modals/logic/use-content-modals.js
+++ b/src/features/content-modals/logic/use-content-modals.js
@@ -24,7 +24,11 @@ export const use_content_modals = () => {
     title: '',
     description: '',
     tags: '',
-    scheduled_time: ''
+    scheduled_time: '',
+    // YouTube API 새로운 필드들
+    privacyStatus: 'private',
+    categoryId: '22', // People & Blogs
+    madeForKids: false
   });
 
   /**
@@ -52,7 +56,11 @@ export const use_content_modals = () => {
       title: item.title,
       description: item.description || '',
       tags: '',
-      scheduled_time: ''
+      scheduled_time: '',
+      // YouTube API 새로운 필드들
+      privacyStatus: 'private',
+      categoryId: '22', // People & Blogs
+      madeForKids: false
     });
     set_publish_modal({ open: true, item });
   };
@@ -67,7 +75,11 @@ export const use_content_modals = () => {
       title: '',
       description: '',
       tags: '',
-      scheduled_time: ''
+      scheduled_time: '',
+      // YouTube API 새로운 필드들 초기화
+      privacyStatus: 'private',
+      categoryId: '22', // People & Blogs
+      madeForKids: false
     });
   };
 

--- a/src/features/content-modals/ui/ContentPublishModal.jsx
+++ b/src/features/content-modals/ui/ContentPublishModal.jsx
@@ -16,6 +16,32 @@ import {
 } from '@/features/content-management/lib/content-launch-utils';
 import { usePlatformStore } from '@/domain/platform/logic/store';
 
+// YouTube 카테고리 목록
+const YOUTUBE_CATEGORIES = {
+  "1": "Film & Animation",
+  "2": "Autos & Vehicles", 
+  "10": "Music",
+  "15": "Pets & Animals",
+  "17": "Sports",
+  "19": "Travel & Events",
+  "20": "Gaming",
+  "22": "People & Blogs",
+  "23": "Comedy",
+  "24": "Entertainment",
+  "25": "News & Politics",
+  "26": "Howto & Style",
+  "27": "Education",
+  "28": "Science & Technology",
+  "29": "Nonprofits & Activism"
+};
+
+// 공개 상태 옵션
+const PRIVACY_OPTIONS = [
+  { value: 'private', label: '비공개', description: '나만 볼 수 있음' },
+  { value: 'unlisted', label: '일부 공개', description: '링크를 아는 사람만' },
+  { value: 'public', label: '공개', description: '모든 사람이 볼 수 있음' }
+];
+
 const ContentPublishModal = ({ 
   is_open, 
   item, 
@@ -162,9 +188,114 @@ const ContentPublishModal = ({
               className={`${
                 dark_mode ? 'bg-gray-800/60 border-gray-600/60' : 'bg-white/60 border-gray-300/60'
               } backdrop-blur-sm rounded-xl`}
-              placeholder="#태그1 #태그2 #태그3"
+              placeholder="태그1, 태그2, 태그3 (쉼표로 구분)"
             />
           </div>
+
+          {/* YouTube 전용 설정 */}
+          {publish_form.platforms.includes('youtube') && (
+            <>
+              {/* 공개 상태 */}
+              <div>
+                <label className={`text-sm font-medium ${dark_mode ? 'text-gray-300' : 'text-gray-700'} mb-3 block`}>
+                  공개 상태
+                </label>
+                <div className="space-y-2">
+                  {PRIVACY_OPTIONS.map((option) => (
+                    <label
+                      key={option.value}
+                      className={`flex items-center gap-3 p-3 rounded-xl border cursor-pointer transition-all ${
+                        publish_form.privacyStatus === option.value
+                          ? dark_mode
+                            ? 'bg-blue-500/20 border-blue-500/50 text-blue-300'
+                            : 'bg-blue-50 border-blue-200 text-blue-700'
+                          : dark_mode
+                            ? 'bg-gray-800/30 border-gray-600/60 hover:bg-gray-700/60'
+                            : 'bg-white/30 border-gray-300/60 hover:bg-gray-50'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="privacyStatus"
+                        value={option.value}
+                        checked={publish_form.privacyStatus === option.value}
+                        onChange={(e) => on_update_form('privacyStatus', e.target.value)}
+                        className="w-4 h-4 text-blue-600"
+                      />
+                      <div>
+                        <div className="font-medium">{option.label}</div>
+                        <div className={`text-xs ${dark_mode ? 'text-gray-400' : 'text-gray-600'}`}>
+                          {option.description}
+                        </div>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              {/* 카테고리 선택 */}
+              <div>
+                <label className={`text-sm font-medium ${dark_mode ? 'text-gray-300' : 'text-gray-700'} mb-2 block`}>
+                  카테고리
+                </label>
+                <select
+                  value={publish_form.categoryId}
+                  onChange={(e) => on_update_form('categoryId', e.target.value)}
+                  className={`w-full p-3 rounded-xl border ${
+                    dark_mode 
+                      ? 'bg-gray-800/60 border-gray-600/60 text-white' 
+                      : 'bg-white/60 border-gray-300/60 text-gray-900'
+                  } backdrop-blur-sm focus:outline-none focus:ring-2 focus:ring-blue-500`}
+                >
+                  {Object.entries(YOUTUBE_CATEGORIES).map(([id, name]) => (
+                    <option key={id} value={id}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* 아동용 여부 */}
+              <div>
+                <label className={`text-sm font-medium ${dark_mode ? 'text-gray-300' : 'text-gray-700'} mb-3 block`}>
+                  아동용 콘텐츠
+                </label>
+                <div className="flex items-center gap-4">
+                  <label className={`flex items-center gap-2 cursor-pointer p-2 rounded-lg transition-colors ${
+                    !publish_form.madeForKids ? 'bg-blue-50 dark:bg-blue-900/20' : ''
+                  }`}>
+                    <input
+                      type="radio"
+                      name="madeForKids"
+                      checked={!publish_form.madeForKids}
+                      onChange={() => on_update_form('madeForKids', false)}
+                      className="w-4 h-4 text-blue-600"
+                    />
+                    <span className={dark_mode ? 'text-gray-300' : 'text-gray-700'}>
+                      아니오
+                    </span>
+                  </label>
+                  <label className={`flex items-center gap-2 cursor-pointer p-2 rounded-lg transition-colors ${
+                    publish_form.madeForKids ? 'bg-blue-50 dark:bg-blue-900/20' : ''
+                  }`}>
+                    <input
+                      type="radio"
+                      name="madeForKids"
+                      checked={publish_form.madeForKids}
+                      onChange={() => on_update_form('madeForKids', true)}
+                      className="w-4 h-4 text-blue-600"
+                    />
+                    <span className={dark_mode ? 'text-gray-300' : 'text-gray-700'}>
+                      예
+                    </span>
+                  </label>
+                </div>
+                <p className={`text-xs mt-2 ${dark_mode ? 'text-gray-400' : 'text-gray-600'}`}>
+                  13세 이하를 대상으로 제작된 콘텐츠인지 선택해주세요.
+                </p>
+              </div>
+            </>
+          )}
 
           {/* 액션 버튼 */}
           <div className="flex items-center gap-3 pt-4 sticky bottom-0 bg-inherit">

--- a/src/features/real-time-notifications/logic/notification-store.js
+++ b/src/features/real-time-notifications/logic/notification-store.js
@@ -140,6 +140,7 @@ export const useNotificationStore = create(
       message: `영상 제작이 완료되었습니다: ${video_data.title || '새 영상'}`,
       data: video_data,
       timestamp: video_data.timestamp || new Date().toISOString(),
+      path: '/contentlaunch' // 클릭 시 이동할 경로 추가
     });
   },
   
@@ -166,6 +167,8 @@ export const useNotificationStore = create(
       read: false,
       timestamp: formatted_timestamp, // 포맷팅된 시간으로 저장
       raw_timestamp: sse_data.timestamp || new Date().toISOString(), // 원본 타임스탬프도 보존
+      // video_completed 타입의 알림에는 contentlaunch 페이지로 이동하는 path 추가
+      ...(sse_data.type === 'video_completed' && { path: '/contentlaunch' })
     };
     
     // 일반 알림을 스토어에 추가 (드롭다운용)

--- a/src/features/real-time-notifications/logic/notification-store.js
+++ b/src/features/real-time-notifications/logic/notification-store.js
@@ -6,40 +6,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-/**
- * 날짜를 yy-mm-dd hh:mm 형식으로 포맷팅하는 함수
- * @param {string|Date} dateString - ISO 문자열 또는 Date 객체
- * @returns {string} yy-mm-dd hh:mm 형식의 날짜 문자열
- */
-function format_date_time(dateString) {
-  try {
-    const date = new Date(dateString);
-    
-    // 유효한 날짜인지 확인
-    if (isNaN(date.getTime())) {
-      return new Date().toLocaleDateString('ko-KR', {
-        year: '2-digit',
-        month: '2-digit', 
-        day: '2-digit',
-        hour: '2-digit',
-        minute: '2-digit'
-      }).replace(/\./g, '-').replace(' ', ' ');
-    }
-    
-    // yy-mm-dd hh:mm 형식으로 포맷팅
-    const year = String(date.getFullYear()).slice(-2);
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    const hours = String(date.getHours()).padStart(2, '0');
-    const minutes = String(date.getMinutes()).padStart(2, '0');
-    
-    return `${year}-${month}-${day} ${hours}:${minutes}`;
-  } catch (error) {
-    console.error('날짜 포맷팅 실패:', error);
-    return format_date_time(new Date()); // 현재 시간으로 대체
-  }
-}
-
 export const useNotificationStore = create(
   persist(
     (set, get) => ({
@@ -62,8 +28,8 @@ export const useNotificationStore = create(
       message: notification.message,
       data: notification.data || {},
       read: false,
-      timestamp: format_date_time(timestamp), // 포맷팅된 시간으로 저장
-      raw_timestamp: timestamp, // 원본 타임스탬프 보존
+      timestamp: timestamp, // 원본 ISO 형식 타임스탬프 저장
+      raw_timestamp: timestamp, // 호환성을 위해 보존
     };
     
     set((state) => ({
@@ -156,8 +122,8 @@ export const useNotificationStore = create(
   
   // SSE 전용 알림 추가 메서드 (다른 스토어와 연동)
   add_sse_notification: (sse_data) => {
-    // 서버로부터 받은 timestamp를 yy-mm-dd hh:mm 형식으로 포맷팅
-    const formatted_timestamp = format_date_time(sse_data.timestamp || new Date().toISOString());
+    // 원본 ISO 형식 타임스탬프 사용
+    const timestamp = sse_data.timestamp || new Date().toISOString();
     
     const new_notification = {
       id: Date.now().toString(),
@@ -165,8 +131,8 @@ export const useNotificationStore = create(
       message: sse_data.message,
       data: sse_data.data || {},
       read: false,
-      timestamp: formatted_timestamp, // 포맷팅된 시간으로 저장
-      raw_timestamp: sse_data.timestamp || new Date().toISOString(), // 원본 타임스탬프도 보존
+      timestamp: timestamp, // 원본 ISO 형식 타임스탬프 저장
+      raw_timestamp: timestamp, // 호환성을 위해 보존
       // video_completed 타입의 알림에는 contentlaunch 페이지로 이동하는 path 추가
       ...(sse_data.type === 'video_completed' && { path: '/contentlaunch' })
     };
@@ -217,7 +183,7 @@ export const useNotificationStore = create(
     get().add_sse_notification({
       type: 'video_completed_sse',
       message: message,
-      timestamp: timestamp, // format_date_time은 add_sse_notification에서 처리
+      timestamp: timestamp, // 원본 ISO 형식 사용
       data: { source: 'sse' },
     });
   },

--- a/src/features/reddit-media-request/logic/use-reddit-request-form.js
+++ b/src/features/reddit-media-request/logic/use-reddit-request-form.js
@@ -1,0 +1,207 @@
+/**
+ * Reddit 이미지 생성 요청 폼 상태 관리 커스텀 훅
+ * YouTube 폼과 동일한 구조이지만 Reddit 특화 처리 로직 포함
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+import { use_content_launch } from '@/features/content-management/logic/use-content-launch';
+import { useNotificationStore } from '@/features/real-time-notifications/logic/notification-store';
+
+/**
+ * useRedditRequestForm 커스텀 훅
+ * @param {Function|null} onRequestSuccess - 요청 성공 콜백 함수
+ * @param {boolean} isPriority - 우선순위 재생성 모드 여부
+ * @param {Object|null} selectedVideoData - 선택된 영상 데이터 (자동 import용)
+ * @returns {Object} 폼 상태와 핸들러들
+ */
+export const useRedditRequestForm = (onRequestSuccess = null, isPriority = false, selectedVideoData = null) => {
+  // 기본 폼 상태
+  const [selectedLocation, setSelectedLocation] = useState(null);
+  const [uploadedFile, setUploadedFile] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  
+  // 자연어 프롬프트 상태
+  const [promptText, setPromptText] = useState('');
+
+  // 위치 선택 핸들러
+  const handleLocationSelect = useCallback((location) => {
+    setSelectedLocation(location);
+  }, []);
+
+  // 파일 변경 핸들러
+  const handleFileChange = useCallback((file) => {
+    setUploadedFile(file);
+  }, []);
+
+  // 프롬프트 변경 핸들러
+  const handlePromptChange = useCallback((value) => {
+    setPromptText(value);
+  }, []);
+
+  // 폼 초기화 함수
+  const resetForm = useCallback(() => {
+    setSelectedLocation(null);
+    setUploadedFile(null);
+    setPromptText('');
+  }, []);
+
+  // 선택된 영상 데이터로 폼 자동 초기화 (YouTube와 동일)
+  useEffect(() => {
+    if (selectedVideoData) {      
+      // 위치 정보 자동 설정
+      if (selectedVideoData.location_name || selectedVideoData.location_id) {
+        const autoLocation = {
+          poi_id: selectedVideoData.location_id,
+          name: selectedVideoData.location_name || '선택된 위치',
+        };
+        setSelectedLocation(autoLocation);
+      }
+      
+      // 이미지 자동 설정 (image_url이 있는 경우)
+      if (selectedVideoData.image_url) {
+        fetch(selectedVideoData.image_url)
+          .then(response => response.blob())
+          .then(blob => {
+            const file = new File([blob], `${selectedVideoData.title || 'selected'}_image.jpg`, {
+              type: blob.type || 'image/jpeg'
+            });
+            setUploadedFile(file);
+          })
+          .catch(error => {
+            console.warn('이미지 자동 로드 실패:', error);
+          });
+      }
+      
+      // 프롬프트 자동 설정 (Reddit용으로 수정)
+      const autoPrompt = selectedVideoData.title 
+        ? `"${selectedVideoData.title}"과 유사한 이미지를 생성해주세요.`
+        : '선택한 영상과 유사한 새로운 이미지를 생성해주세요.';
+      setPromptText(autoPrompt);
+    } else {
+      // 선택된 영상이 없으면 폼 초기화
+      resetForm();
+    }
+  }, [selectedVideoData, resetForm]);
+
+  // 폼 제출 핸들러 (현재는 준비 중 알림만 표시)
+  const handleSubmit = useCallback(async () => {
+    // 필수 항목 검증
+    if (!selectedLocation) {
+      alert('위치를 선택해주세요.');
+      return;
+    }
+
+    if (!uploadedFile) {
+      alert('참고 이미지를 업로드해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      // 이미지를 Base64로 변환 (UI 표시용)
+      const convertToBase64 = (file) => {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.readAsDataURL(file);
+          reader.onload = () => resolve(reader.result);
+          reader.onerror = error => reject(error);
+        });
+      };
+
+      const imageUrl = await convertToBase64(uploadedFile);
+      
+      // 현재 날짜 생성 (YYYY-MM-DD 형식)
+      const creationDate = new Date().toISOString().split('T')[0];
+      
+      // Reddit 이미지 데이터 구성 (temp_id 명시적 생성)
+      const imageTempId = `reddit-temp-${Date.now()}`;
+      const imageData = {
+        temp_id: imageTempId,
+        title: `${selectedLocation.name} Reddit 이미지`,
+        location_id: selectedLocation.poi_id,
+        location_name: selectedLocation.name,
+        image_url: imageUrl,
+        user_request: promptText && promptText.trim() ? promptText.trim() : null,
+        platform: 'reddit' // 플랫폼 구분자 추가
+      };
+      
+      // 🚀 낙관적 UI: on_request_success 콜백을 즉시 실행하여 UI가 먼저 반응
+      if (onRequestSuccess) {
+        onRequestSuccess({
+          video_data: imageData, // 기존 구조 유지를 위해 video_data로 명명
+          creation_date: creationDate,
+          isPriority
+        });
+      } else {
+        // 기존 방식: 직접 Zustand 스토어 호출
+        if (isPriority) {
+          use_content_launch.getState().replace_processing_video(imageData, creationDate);
+        } else {
+          use_content_launch.getState().add_pending_video(imageData, creationDate);
+        }
+      }
+      
+      // 폼 초기화
+      resetForm();
+      
+      // Reddit API 준비 중 알림 (실제 API 대신)
+      useNotificationStore.getState().add_notification({
+        type: 'info',
+        message: 'Reddit 이미지 생성 기능이 준비 중입니다. 백엔드 API 개발이 완료되면 실제 처리됩니다.',
+        data: { 
+          temp_id: imageTempId,
+          platform: 'reddit',
+          status: 'api_pending'
+        }
+      });
+      
+      // TODO: 실제 Reddit 이미지 생성 API가 준비되면 여기에 구현
+      // 🔄 백그라운드 처리: Reddit 이미지 생성 API 호출
+      // (async () => {
+      //   try {
+      //     await uploadImageToRedditGenerate(
+      //       uploadedFile,
+      //       selectedLocation.poi_id,
+      //       promptText && promptText.trim() ? promptText.trim() : ""
+      //     );
+      //   } catch (backgroundError) {
+      //     use_content_launch.getState().transition_to_failed(imageTempId);
+      //     useNotificationStore.getState().add_notification({
+      //       type: 'error',
+      //       message: `Reddit 이미지 생성에 실패했습니다: ${backgroundError.message}`,
+      //       data: { 
+      //         error: backgroundError.message,
+      //         temp_id: imageTempId,
+      //         failed_at: new Date().toISOString()
+      //       }
+      //     });
+      //   }
+      // })();
+      
+    } catch (error) {
+      alert('요청 전송에 실패했습니다. 다시 시도해주세요.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [selectedLocation, uploadedFile, promptText, resetForm, onRequestSuccess, isPriority]);
+
+  // 폼 검증 상태
+  const isFormValid = selectedLocation && uploadedFile && !isSubmitting;
+
+  return {
+    // 상태
+    selectedLocation,
+    uploadedFile,
+    promptText,
+    isSubmitting,
+    isFormValid,
+    
+    // 핸들러
+    handleLocationSelect,
+    handleFileChange,
+    handlePromptChange,
+    handleSubmit,
+    resetForm
+  };
+};

--- a/src/features/reddit-media-request/ui/RedditRequestForm.jsx
+++ b/src/features/reddit-media-request/ui/RedditRequestForm.jsx
@@ -1,0 +1,81 @@
+/**
+ * Reddit 이미지 생성 요청 폼 컴포넌트
+ * 기존 YouTube 폼과 동일한 구조로 구현 (위치, 이미지, 프롬프트)
+ */
+
+import React from 'react';
+import LocationSelector from '@/common/ui/location-selector';
+import ImageUploader from '@/common/ui/image-uploader';
+import NaturalPromptInput from '@/common/ui/natural-prompt-input';
+import { useRedditRequestForm } from '@/features/reddit-media-request/logic/use-reddit-request-form';
+
+/**
+ * Reddit 이미지 생성 요청 폼 컴포넌트
+ * @param {Object} props - 컴포넌트 props
+ * @param {Function} props.onRequestSuccess - 요청 성공 시 콜백 함수
+ * @param {Object|null} props.selectedVideoData - 선택된 영상 데이터 (자동 import용)
+ * @param {boolean} props.isPriority - 우선순위 재생성 모드 여부
+ * @returns {JSX.Element} Reddit 이미지 생성 요청 폼 컴포넌트
+ */
+const RedditRequestForm = ({ onRequestSuccess = null, selectedVideoData = null, isPriority = false }) => {
+  // 폼 상태 관리 커스텀 훅 사용
+  const {
+    selectedLocation,
+    uploadedFile,
+    promptText,
+    isSubmitting,
+    isFormValid,
+    handleLocationSelect,
+    handleFileChange,
+    handlePromptChange,
+    handleSubmit
+  } = useRedditRequestForm(onRequestSuccess, isPriority, selectedVideoData);
+
+  return (
+    <div className="space-y-5">
+      {/* 위치 선택 컴포넌트 */}
+      <LocationSelector
+        selected_location={selectedLocation}
+        on_location_select={handleLocationSelect}
+      />
+
+      {/* 이미지 업로드 컴포넌트 */}
+      <ImageUploader
+        uploaded_file={uploadedFile}
+        on_file_change={handleFileChange}
+      />
+
+      {/* 자연어 프롬프트 입력 컴포넌트 */}
+      <NaturalPromptInput
+        prompt_text={promptText}
+        on_prompt_change={handlePromptChange}
+        placeholder="Reddit에 업로드할 이미지를 어떻게 생성할지 설명해주세요..."
+      />
+
+      {/* Reddit 준비 중 안내 */}
+      <div className="p-4 bg-amber-50/50 dark:bg-amber-900/20 border border-amber-200/30 dark:border-amber-700/30 rounded-xl">
+        <div className="flex items-center gap-3">
+          <div className="w-2 h-2 bg-amber-500 rounded-full animate-pulse"></div>
+          <p className="text-sm text-amber-700 dark:text-amber-300">
+            <span className="font-semibold">Reddit 이미지 생성 기능 준비 중</span>
+            <br />
+            현재 백엔드 API 개발 중입니다. 폼 제출 시 준비 중 메시지가 표시됩니다.
+          </p>
+        </div>
+      </div>
+
+      {/* 제출 버튼 (숨김 - 모달에서 처리) */}
+      <button
+        type="button"
+        onClick={handleSubmit}
+        disabled={!isFormValid}
+        className="hidden"
+        id="reddit-form-submit"
+      >
+        {isSubmitting ? '요청 중...' : '이미지 생성 요청하기'}
+      </button>
+    </div>
+  );
+};
+
+export default RedditRequestForm;

--- a/src/pages/ContentLaunchPage.jsx
+++ b/src/pages/ContentLaunchPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { TestTube } from 'lucide-react';
 import { usePageStore } from '@/common/stores/page-store';
@@ -16,6 +16,7 @@ import { Button } from '@/common/ui/button';
 const ContentLaunchPage = () => {
   const { isDarkMode } = usePageStore();
   const [showTestPanel, setShowTestPanel] = useState(false);
+  const contentLaunchViewRef = useRef(null);
 
   return (
     <DashboardLayout currentView="contentLaunch" title="AI 콘텐츠 론칭">
@@ -37,21 +38,32 @@ const ContentLaunchPage = () => {
       </div>
 
       <div className="px-8 py-6">
-        {/* 테스트 패널 (조건부 렌더링) */}
-        <AnimatePresence>
-          {showTestPanel && (
-            <VideoStreamTestPanel dark_mode={isDarkMode} />
-          )}
-        </AnimatePresence>
-        
         {/* 콘텐츠 론칭 뷰 */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.3 }}
         >
-          <ContentLaunchView dark_mode={isDarkMode} />
+          <ContentLaunchView 
+            ref={contentLaunchViewRef}
+            dark_mode={isDarkMode}
+          />
         </motion.div>
+        
+        {/* 테스트 패널 (조건부 렌더링) */}
+        <AnimatePresence>
+          {showTestPanel && (
+            <VideoStreamTestPanel 
+              dark_mode={isDarkMode}
+              on_upload_test={(jobId, resultId) => {
+                // ContentLaunchView의 핸들러 함수를 직접 호출
+                if (contentLaunchViewRef.current) {
+                  contentLaunchViewRef.current.handle_open_upload_test_modal(jobId, resultId);
+                }
+              }}
+            />
+          )}
+        </AnimatePresence>
       </div>
     </DashboardLayout>
   );


### PR DESCRIPTION
## 어떤 점이 개선되었나요?

이번 PR은 YouTube 콘텐츠 업로드 기능의 전체 워크플로우를 구현하고, 사용자 경험을 저해하던 주요 버그들을 수정하는 데 중점을 두었습니다. 또한, 개발 편의성을 높이기 위한 테스트 기능을 추가했습니다.

## 🚀 YouTube 업로드 기능 구현

- **업로드 모달 확장**: YouTube에 영상을 게시할 때 필요한 모든 메타데이터(공개 상태, 카테고리, 아동용 여부)를 설정할 수 있도록 게시 모달 UI를 확장했습니다.
- **API 연동**: `POST /api/youtube/upload/{jobId}/result/{resultId}` API와 연동하여, 모달에서 입력한 정보로 실제 YouTube에 영상이 업로드되도록 구현했습니다.
- **데이터 처리**: 프론트엔드에서 입력된 태그(쉼표로 구분된 문자열)를 백엔드가 요구하는 배열 형태로 자동 변환하는 로직을 추가했습니다.

## 🛠️ 개발 편의성 향상 (업로드 테스트 기능)

- 영상 생성 과정을 건너뛰고 업로드 기능만 독립적으로 테스트할 수 있도록 **`콘텐츠 론칭`** 페이지에 테스트 패널을 추가했습니다.
- 개발자는 `jobId`와 `resultId`를 직접 입력하여 게시 모달을 즉시 열고, 업로드 API 호출을 테스트할 수 있습니다.

## 🐛 주요 버그 수정

1. **알림 'Invalid Date' 오류 해결**:
    - **원인**: 알림 생성 시 날짜가 문자열로 미리 변환된 후, UI에서 다시 `new Date()`로 파싱하려다 발생하던 오류였습니다.
    - **해결**: 데이터는 원본(ISO) 형식으로 저장하고, UI단에서만 포맷팅하도록 수정했습니다. 또한, 여러 곳에 흩어져 있던 날짜 처리 함수들을 `date-utils.js`로 통합하여 코드 중복을 제거하고 일관성을 확보했습니다.
2. **미디어 생성 시 DB `NOT NULL` 오류 해결**:
    - **원인**: 미디어 생성 요청 시 `result_type` 필드가 누락되어 발생하던 백엔드 데이터베이스 오류였습니다.
    - **해결**: 모든 미디어 생성 API 호출 시 요청 본문에 `'YOUTUBE'` 또는 `'REDDIT'`과 같은 미디어 유형을 명시적으로 포함하도록 수정했습니다.

## 기타 개선 사항

- **Reddit 기능 임시 비활성화**: 아직 개발 중인 Reddit 미디어 생성 기능은 사용자가 선택할 수 없도록 UI 상에서 비활성화 처리했습니다. 이를 통해 현재 구현이 완료된 YouTube 기능 테스트에 집중할 수 있습니다.

## 어떻게 테스트하나요?

1. `콘텐츠 론칭` 페이지로 이동하여 **"🧪 API 테스트 패널"** 버튼을 클릭합니다.
2. "YouTube 업로드 테스트" 섹션에 테스트용 `jobId`와 `resultId`를 입력하고 **"업로드 테스트 모달 열기"** 버튼을 클릭합니다.
3. 게시 모달이 열리면, 새로 추가된 **공개 상태, 카테고리, 아동용 여부** 필드를 설정하고 **"지금 게시하기"** 버튼을 클릭하여 API 호출이 성공하는지 확인합니다.
4. 작업 성공 후, 우측 상단 알림 아이콘을 클릭하여 알림 메시지의 시간이 **'Invalid Date'가 아닌 정상적인 시간**으로 표시되는지 확인합니다.
5. `AI 미디어 제작 요청` 모달에서 **Reddit 플랫폼 버튼이 비활성화**되어 클릭되지 않는지 확인합니다.