### PR TITLE
Youtube/Reddit 분석 기능 개선 및 API 연동

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -13,9 +13,9 @@ import SSEProvider from '@/common/ui/SSEProvider';
 export default function App() {
   const { isDarkMode, setIsDarkMode } = usePageStore();
   const { platforms } = usePlatformStore();
-  usePlatformInitializer();
 
   const [bootDone, setBootDone] = useState(false);
+  usePlatformInitializer(bootDone);
   const navigate = useNavigate();
   const location = useLocation();
 

--- a/src/common/api/api.js
+++ b/src/common/api/api.js
@@ -429,7 +429,30 @@ export async function getRedditContentById(postId) {
 }
 
 
+/* ------------------Demographics 차트 조회 ------------------ */
 
+
+export async function getYouTubeDailyDemographics(startDate, endDate) {
+  try {
+    const res = await apiFetch(`/api/youtube/daily-demographics`, {
+      method: "POST",
+      body: JSON.stringify({ startDate, endDate }),
+    });
+
+    if (!res.ok) {
+      const errorData = await res.json().catch(() => ({}));
+      throw new Error(
+        `유튜브 데모그래픽 조회 실패: ${res.status} - ${errorData.message || "알 수 없는 오류"}`
+      );
+    }
+
+    const data = await res.json();
+    return data; // { data: [...], message, status }
+  } catch (error) {
+    console.error("❌ getYouTubeDailyDemographics error:", error);
+    throw error;
+  }
+}
 
 /* ------------------ 영상 데이터 조회 (SSE 사전 로딩용) ------------------ */
 /**

--- a/src/common/api/api.js
+++ b/src/common/api/api.js
@@ -268,31 +268,39 @@ export async function getYouTubeUploadsByRange(startDate, endDate, channelId) {
   return await res.json();
 }
 
+
+/* ------------------ traffic-source-summary 조회 ------------------ */
+
 /**
- * 특정 영상의 트래픽 소스 요약 조회
- * @param {string} videoId - 유튜브 영상 ID
- * @returns {Promise} 트래픽 소스 데이터
+ * 특정 기간의 트래픽 소스 요약 조회
+ * @param {string} startDate - 시작일 (YYYY-MM-DD)
+ * @param {string} endDate - 종료일 (YYYY-MM-DD)
+ * @returns {Promise<{data: Array, message: string, status: number}>}
  */
-export async function get_traffic_source_summary(videoId) {
-  if (!videoId) {
-    throw new Error('Video ID가 필요합니다.');
+export async function getTrafficSourceSummary(startDate, endDate) {
+  if (!startDate || !endDate) {
+    throw new Error("startDate, endDate are required.");
   }
 
-  const url = `/api/youtube/traffic-source-summary/${videoId}`;
-
-  const res = await apiFetch(url, {
-    method: 'POST'
+  const res = await apiFetch("/api/youtube/traffic-source-summary", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ startDate, endDate }),
   });
 
   if (!res.ok) {
-    const errorData = await res.json().catch(() => ({ message: '알 수 없는 오류가 발생했습니다.' }));
-    throw new Error(`트래픽 소스 조회 실패: ${res.status} - ${errorData.message}`);
+    const errorData = await res.json().catch(() => ({}));
+    throw new Error(
+      `트래픽 소스 요약 조회 실패: ${res.status} - ${
+        errorData.message || "알 수 없는 오류"
+      }`
+    );
   }
-  
-  const responseData = await res.json();
-  
-  return responseData;
+
+  return await res.json(); // { data: [...], message, status }
 }
+
+
 /* ------------------ Reddit 대시보드 데이터 조회 ------------------ */
 /**
  * @param {string} startDate - 시작일 (YYYY-MM-DD)

--- a/src/common/ui/AudienceDemographicsChart.jsx
+++ b/src/common/ui/AudienceDemographicsChart.jsx
@@ -1,10 +1,9 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { motion } from 'framer-motion';
 import { Users } from 'lucide-react';
-import { audience_demo_data } from '@/domain/dashboard/logic/dashboard-constants';
 import GlassCard from '@/common/ui/glass-card';
 
-const AudienceDemographicsChart = () => {
+const AudienceDemographicsChart = ({ data }) => {
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -12,17 +11,15 @@ const AudienceDemographicsChart = () => {
       transition={{ duration: 0.5, delay: 0.4 }}
     >
       <GlassCard className="p-6" hover={true}>
-        {/* 헤더 */}
         <motion.div 
           className="flex items-center gap-4 mb-6"
           initial={{ opacity: 0, x: -20 }}
           animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.5, delay: 0.4, ease: [0.16, 1, 0.3, 1] }}
+          transition={{ duration: 0.5, delay: 0.4 }}
         >
           <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-green-500/30 to-cyan-500/30 backdrop-blur-sm border border-white/40 dark:border-white/20 flex items-center justify-center shadow-lg">
             <Users className="w-6 h-6 text-green-600 dark:text-green-400" />
           </div>
-          
           <div>
             <h3 className="text-xl font-semibold text-gray-800 dark:text-white">
               시청자 분포 분석
@@ -33,18 +30,14 @@ const AudienceDemographicsChart = () => {
           </div>
         </motion.div>
 
-        {/* 차트 */}
         <motion.div
           className="h-80 sm:h-96 w-full relative"
           initial={{ opacity: 0, scale: 0.9 }}
           animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.6, delay: 0.5, ease: [0.16, 1, 0.3, 1] }}
+          transition={{ duration: 0.6, delay: 0.5 }}
         >
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={audience_demo_data}
-              margin={{ top: 5, right: 20, left: -10, bottom: 5 }}
-            >
+            <BarChart data={data} margin={{ top: 5, right: 20, left: -10, bottom: 5 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="currentColor" opacity={0.1} />
               <XAxis dataKey="age" tick={{ fontSize: 12, fill: 'currentColor', opacity: 0.7 }} />
               <YAxis tick={{ fontSize: 12, fill: 'currentColor', opacity: 0.7 }} />

--- a/src/common/ui/VideoAnalysisModal.jsx
+++ b/src/common/ui/VideoAnalysisModal.jsx
@@ -28,7 +28,7 @@ const VideoAnalysisModal = ({ contentId, title, platform, onClose }) => {
           commentData = await getRedditCommentAnalysis(contentId);
         }
         setCommentAnalysisData(commentData);
-        console.log("Reddit Comment Analysis Data:", commentData);
+
       } catch (err) {
         setError(String(err));
       } finally {
@@ -62,21 +62,6 @@ const VideoAnalysisModal = ({ contentId, title, platform, onClose }) => {
                 <div className="text-white">미리보기를 제공하지 않는 플랫폼입니다.</div>
               )}
             </div>
-            {/* <GlassCard>
-              <div className="p-6">
-                <div className="flex items-center gap-3 mb-4">
-                  <BarChart2 className="w-6 h-6 text-blue-500" />
-                  <h3 className="text-lg font-semibold">트래픽 소스</h3>
-                </div>
-                {loading ? (
-                  <div className="flex justify-center items-center h-48">
-                    <Loader2 className="w-8 h-8 animate-spin text-blue-500" />
-                  </div>
-                ) : (
-                  <TrafficSourceChart data={trafficSourceData} />
-                )}
-              </div>
-            </GlassCard> */}
           </div>
           <div className="col-span-1">
             <DialogClose asChild>
@@ -89,29 +74,29 @@ const VideoAnalysisModal = ({ contentId, title, platform, onClose }) => {
               </button>
             </DialogClose>
             <div className="space-y-4">
-                <DialogTitle asChild>
-                  <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{title || '영상 분석'}</h2>
-                </DialogTitle>
-                <DialogDescription className="text-sm text-gray-600 dark:text-gray-400">
-                  이 영상에 대한 상세 분석 결과입니다.
-                </DialogDescription>
+              <DialogTitle asChild>
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{title || '영상 분석'}</h2>
+              </DialogTitle>
+              <DialogDescription className="text-sm text-gray-600 dark:text-gray-400">
+                이 영상에 대한 상세 분석 결과입니다.
+              </DialogDescription>
             </div>
             <div className="mt-6">
               <GlassCard>
                 <div className="p-6">
-                    <div className="flex items-center gap-3 mb-4">
-                        <MessageSquare className="w-6 h-6 text-green-500" />
-                        <h3 className="text-lg font-semibold">댓글 반응 분석</h3>
+                  <div className="flex items-center gap-3 mb-4">
+                    <MessageSquare className="w-6 h-6 text-green-500" />
+                    <h3 className="text-lg font-semibold">댓글 반응 분석</h3>
+                  </div>
+                  {loading ? (
+                    <div className="flex justify-center items-center h-48">
+                      <Loader2 className="w-8 h-8 animate-spin text-green-500" />
                     </div>
-                    {loading ? (
-                        <div className="flex justify-center items-center h-48">
-                            <Loader2 className="w-8 h-8 animate-spin text-green-500" />
-                        </div>
-                    ) : error ? (
-                        <div className="text-center text-red-500">오류: {error}</div>
-                    ) : (
-                        <CommentAnalysisView data={commentAnalysisData} />
-                    )}
+                  ) : error ? (
+                    <div className="text-center text-red-500">오류: {error}</div>
+                  ) : (
+                    <CommentAnalysisView data={commentAnalysisData} />
+                  )}
                 </div>
               </GlassCard>
             </div>

--- a/src/common/ui/VideoAnalysisModal.jsx
+++ b/src/common/ui/VideoAnalysisModal.jsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { Dialog, DialogContent, DialogClose, DialogTitle, DialogDescription } from '@/common/ui/dialog';
 import { X as XIcon, Loader2, MessageSquare } from 'lucide-react';
-import { getCommentAnalysis, getRedditCommentAnalysis } from '@/common/api/api';
+import { getCommentAnalysis, getRedditCommentAnalysis, getRedditContentById } from '@/common/api/api';
 import CommentAnalysisView from '@/features/content-modals/ui/CommentAnalysisView';
 import GlassCard from '@/common/ui/glass-card';
 
 const VideoAnalysisModal = ({ contentId, title, platform, onClose }) => {
   const [commentAnalysisData, setCommentAnalysisData] = useState(null);
-  const [trafficSourceData, setTrafficSourceData] = useState(null);
+  const [redditContent, setRedditContent] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -21,14 +21,17 @@ const VideoAnalysisModal = ({ contentId, title, platform, onClose }) => {
       setLoading(true);
       setError(null);
       try {
-        let commentData;
         if (platform === 'youtube') {
-          commentData = await getCommentAnalysis(contentId);
+          const commentData = await getCommentAnalysis(contentId);
+          setCommentAnalysisData(commentData);
         } else if (platform === 'reddit') {
-          commentData = await getRedditCommentAnalysis(contentId);
+          const [postData, commentData] = await Promise.all([
+            getRedditContentById(contentId),
+            getRedditCommentAnalysis(contentId)
+          ]);
+          setRedditContent(postData);
+          setCommentAnalysisData(commentData);
         }
-        setCommentAnalysisData(commentData);
-
       } catch (err) {
         setError(String(err));
       } finally {
@@ -39,31 +42,67 @@ const VideoAnalysisModal = ({ contentId, title, platform, onClose }) => {
     fetchAnalysisData();
   }, [contentId, platform]);
 
-  const youtubeEmbedUrl = contentId && platform === 'youtube' ? `https://www.youtube.com/embed/${contentId}` : '';
+  const youtubeEmbedUrl =
+    contentId && platform === 'youtube'
+      ? `https://www.youtube.com/embed/${contentId}`
+      : '';
 
   return (
     <Dialog open={!!contentId} onOpenChange={(open) => !open && onClose?.()}>
       <DialogContent className="max-w-6xl w-[90vw] bg-white/80 dark:bg-gray-900/80 backdrop-blur-2xl rounded-3xl shadow-xl border p-8 overflow-y-auto max-h-[90vh]">
         <div className="grid grid-cols-3 gap-8">
+          {/* 왼쪽 콘텐츠 영역 */}
           <div className="col-span-2 space-y-6">
-            <div className="relative w-full aspect-video bg-black rounded-xl overflow-hidden flex items-center justify-center">
-              {platform === 'youtube' && youtubeEmbedUrl ? (
-                <iframe
-                  src={youtubeEmbedUrl}
-                  title={title || 'YouTube video player'}
-                  frameBorder="0"
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                  allowFullScreen
-                  className="w-full h-full"
-                ></iframe>
-              ) : platform === 'youtube' ? (
-                <div className="text-white">비디오 ID가 없습니다.</div>
-              ) : (
-                <div className="text-white">미리보기를 제공하지 않는 플랫폼입니다.</div>
-              )}
-            </div>
+            {platform === 'youtube' ? (
+              <div className="relative w-full aspect-video bg-black rounded-xl overflow-hidden flex items-center justify-center">
+                {youtubeEmbedUrl ? (
+                  <iframe
+                    src={youtubeEmbedUrl}
+                    title={title || 'YouTube video player'}
+                    frameBorder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowFullScreen
+                    className="w-full h-full"
+                  ></iframe>
+                ) : (
+                  <div className="text-white">비디오 ID가 없습니다.</div>
+                )}
+              </div>
+            ) : platform === 'reddit' ? (
+              <div
+                className={`w-full h-full p-6 rounded-xl overflow-y-auto ${
+                  error
+                    ? 'flex items-center justify-center text-red-500'
+                    : 'bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white'
+                }`}
+              >
+                {loading ? (
+                  <p>Reddit 게시글을 불러오는 중...</p>
+                ) : redditContent ? (
+                  <div>
+                    <h3 className="text-lg font-bold mb-2">{redditContent.title}</h3>
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                      in r/{redditContent.sub_reddit} on{' '}
+                      {new Date(redditContent.upload_date).toLocaleDateString('ko-KR')}
+                    </p>
+                    <div
+                      className="prose prose-sm max-w-none dark:prose-invert"
+                      dangerouslySetInnerHTML={{ __html: redditContent.text }}
+                    ></div>
+                  </div>
+                ) : (
+                  <p>게시글을 불러오지 못했습니다.</p>
+                )}
+              </div>
+            ) : (
+              <div className="w-full h-full flex items-center justify-center bg-gray-700 text-white rounded-xl">
+                미리보기를 제공하지 않는 플랫폼입니다.
+              </div>
+            )}
           </div>
-          <div className="col-span-1">
+
+          {/* 오른쪽 분석 영역 */}
+          <div className="col-span-1 relative">
             <DialogClose asChild>
               <button
                 type="button"
@@ -73,14 +112,22 @@ const VideoAnalysisModal = ({ contentId, title, platform, onClose }) => {
                 <XIcon className="h-5 w-5" />
               </button>
             </DialogClose>
+
             <div className="space-y-4">
               <DialogTitle asChild>
-                <h2 className="text-2xl font-bold text-gray-900 dark:text-white">{title || '영상 분석'}</h2>
+                <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+                  {title || (platform === 'reddit' ? 'Reddit 게시글 분석' : '영상 분석')}
+                </h2>
               </DialogTitle>
               <DialogDescription className="text-sm text-gray-600 dark:text-gray-400">
-                이 영상에 대한 상세 분석 결과입니다.
+                {platform === 'youtube'
+                  ? '이 영상에 대한 상세 분석 결과입니다.'
+                  : platform === 'reddit'
+                  ? '이 게시글에 대한 상세 분석 결과입니다.'
+                  : '분석 결과를 확인할 수 없습니다.'}
               </DialogDescription>
             </div>
+
             <div className="mt-6">
               <GlassCard>
                 <div className="p-6">

--- a/src/common/utils/transformDemographics.js
+++ b/src/common/utils/transformDemographics.js
@@ -1,0 +1,25 @@
+export function transformDemographics(apiResponse) {
+  if (!apiResponse?.data) return [];
+
+  // 날짜별 demographic 데이터를 합산
+  const aggregated = {};
+  apiResponse.data.forEach((entry) => {
+    entry.demographics.forEach(({ ageGroup, gender, viewerPercentage }) => {
+      const cleanedAgeGroup = ageGroup.replace('age', ''); // 'age' 접두사 제거
+      if (!aggregated[cleanedAgeGroup]) {
+        aggregated[cleanedAgeGroup] = { age: cleanedAgeGroup, male: 0, female: 0 };
+      }
+      aggregated[cleanedAgeGroup][gender] += viewerPercentage;
+    });
+  });
+
+  // 최종 데이터를 포맷팅하여 반환
+  const formatted = Object.values(aggregated).map(item => ({
+    ...item,
+    // 소수점 3자리까지 반올림
+    male: parseFloat(item.male.toFixed(3)),
+    female: parseFloat(item.female.toFixed(3)),
+  }));
+
+  return formatted;
+}

--- a/src/containers/AnalyticsView/index.jsx
+++ b/src/containers/AnalyticsView/index.jsx
@@ -20,7 +20,7 @@ import { usePlatformStore } from '@/domain/platform/logic/store';
 import { get_kpi_data_from_api } from '@/domain/dashboard/logic/dashboard-utils';
 import AnalyticsFilterSidebar from '@/containers/AnalyticsFilterSidebar/index';
 import Notification from '@/common/ui/notification';
-import AudienceDemographicsChart from '@/common/ui/AudienceDemographicsChart';
+import AudienceDemoContainer from '@/containers/AudienceDemoContainer/index'; // ✅ 수정
 import TrafficSourceChart from '@/common/ui/TrafficSourceChart';
 import UploadedContentList from '@/features/content-management/ui/UploadedContentList';
 import IntegratedAnalyticsView from '@/containers/IntegratedAnalyticsView';
@@ -54,11 +54,20 @@ const DetailedAnalyticsView = ({ current_view, set_current_view, onVideoCardClic
     if ((selected_platform === 'youtube' && isYoutubeConnected) || (selected_platform === 'reddit' && isRedditConnected)) {
       fetchSummaryData();
     }
-  }, [platforms.google.connected, platforms.reddit.connected, platforms.google.loading, platforms.reddit.loading, selected_platform, fetchSummaryData]);
+  }, [
+    platforms.google.connected, 
+    platforms.reddit.connected, 
+    platforms.google.loading, 
+    platforms.reddit.loading, 
+    selected_platform, 
+    fetchSummaryData
+  ]);
 
   const kpiData = get_kpi_data_from_api(selected_platform, summaryData);
 
-  const isSelectedPlatformConnected = selected_platform === 'youtube' ? platforms.google.connected : platforms.reddit.connected;
+  const isSelectedPlatformConnected = selected_platform === 'youtube' 
+    ? platforms.google.connected 
+    : platforms.reddit.connected;
 
   return (
     <div className="h-screen bg-white dark:bg-gray-900 transition-colors duration-300 flex overflow-hidden">
@@ -166,12 +175,19 @@ const DetailedAnalyticsView = ({ current_view, set_current_view, onVideoCardClic
                 })}
               </div>
 
-              <UploadedContentList startDate={date_range?.from} endDate={date_range?.to} onVideoCardClick={onVideoCardClick} selectedPlatform={selected_platform} />
-              
+              <UploadedContentList 
+                startDate={date_range?.from} 
+                endDate={date_range?.to} 
+                onVideoCardClick={onVideoCardClick} 
+                selectedPlatform={selected_platform} 
+              />
 
               <div className="grid grid-cols-2 gap-8">
-                <AudienceDemographicsChart />
-                
+                {/* ✅ AudienceDemoContainer로 교체 */}
+                <AudienceDemoContainer 
+                  startDate={date_range?.from} 
+                  endDate={date_range?.to} 
+                />
 
                 <TrafficSourceChart />
               </div>

--- a/src/containers/AnalyticsView/index.jsx
+++ b/src/containers/AnalyticsView/index.jsx
@@ -182,15 +182,17 @@ const DetailedAnalyticsView = ({ current_view, set_current_view, onVideoCardClic
                 selectedPlatform={selected_platform} 
               />
 
-              <div className="grid grid-cols-2 gap-8">
-                {/* ✅ AudienceDemoContainer로 교체 */}
-                <AudienceDemoContainer 
-                  startDate={date_range?.from} 
-                  endDate={date_range?.to} 
-                />
+              {selected_platform === 'youtube' && (
+                <div className="grid grid-cols-2 gap-8">
+                  {/* AudienceDemoContainer로 교체 */}
+                  <AudienceDemoContainer 
+                    startDate={date_range?.from} 
+                    endDate={date_range?.to} 
+                  />
 
-                <TrafficSourceChart />
-              </div>
+                  <TrafficSourceChart />
+                </div>
+              )}
             </div>
           )}
         </main>

--- a/src/containers/AudienceDemoContainer/index.jsx
+++ b/src/containers/AudienceDemoContainer/index.jsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { getYouTubeDailyDemographics } from "@/common/api/api";
+import { transformDemographics } from "@/common/utils/transformDemographics";
+import AudienceDemographicsChart from "@/common/ui/AudienceDemographicsChart";
+
+function AudienceDemoContainer({ startDate, endDate }) {
+  const [chartData, setChartData] = useState([]);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        if (!startDate || !endDate) return;
+
+        // 날짜를 YYYY-MM-DD 문자열로 변환
+        const start = new Date(startDate).toISOString().slice(0, 10);
+        const end = new Date(endDate).toISOString().slice(0, 10);
+
+        const res = await getYouTubeDailyDemographics(start, end);
+        const transformed = transformDemographics(res);
+        setChartData(transformed);
+      } catch (e) {
+        console.error("AudienceDemoContainer fetch error:", e);
+      }
+    }
+    fetchData();
+  }, [startDate, endDate]);
+
+  return <AudienceDemographicsChart data={chartData} />;
+}
+
+export default AudienceDemoContainer;

--- a/src/domain/analytics/logic/store.js
+++ b/src/domain/analytics/logic/store.js
@@ -262,7 +262,7 @@ function getCategoryName(categoryCode) {
     'NOTIFICATION': '알림',
     'PLAYLIST': '재생목록',
     'YT_OTHER_PAGE': '기타 유튜브 페이지',
-    'NO_LINK_OTHER': '알 수 없는 직접 액세스',
+    'NO_LINK_OTHER': '기타',
     'SUBSCRIBER': '구독자',
     'RELATED_VIDEO': '관련 영상'
   };

--- a/src/domain/platform/logic/store.js
+++ b/src/domain/platform/logic/store.js
@@ -3,8 +3,8 @@ import { create } from 'zustand';
 
 const usePlatformStore = create((set) => ({
   platforms: {
-    google: { connected: false, linked: false, loading: true },
-    reddit: { connected: false, loading: true },
+    google: { connected: false, linked: false, loading: false },
+    reddit: { connected: false, loading: false },
   },
   setPlatformStatus: (platform, status) =>
     set((state) => ({

--- a/src/domain/platform/logic/use-platform-initializer.js
+++ b/src/domain/platform/logic/use-platform-initializer.js
@@ -37,7 +37,7 @@ export const usePlatformInitializer = () => {
   }, [setPlatformStatus, setChannelInfo]);
 
   useEffect(() => {
-    initializePlatforms();
+    // initializePlatforms();
   }, [initializePlatforms]);
 
   // This hook no longer returns a loading state, as it's now managed in the store.

--- a/src/domain/platform/logic/use-platform-initializer.js
+++ b/src/domain/platform/logic/use-platform-initializer.js
@@ -4,7 +4,7 @@ import { usePlatformStore } from '@/domain/platform/logic/store';
 import { useYouTubeStore } from '@/domain/youtube/logic/store';
 import { getGoogleStatus, getRedditStatus } from '@/common/api/api';
 
-export const usePlatformInitializer = () => {
+export const usePlatformInitializer = (bootDone) => {
   const { setPlatformStatus } = usePlatformStore();
   const { setChannelInfo } = useYouTubeStore();
 
@@ -37,8 +37,10 @@ export const usePlatformInitializer = () => {
   }, [setPlatformStatus, setChannelInfo]);
 
   useEffect(() => {
-    // initializePlatforms();
-  }, [initializePlatforms]);
+    if (bootDone) {
+      initializePlatforms();
+    }
+  }, [bootDone, initializePlatforms]);
 
   // This hook no longer returns a loading state, as it's now managed in the store.
 };

--- a/src/features/content-management/ui/UploadedContentList.jsx
+++ b/src/features/content-management/ui/UploadedContentList.jsx
@@ -104,9 +104,15 @@ const UploadedContentList = ({ startDate, endDate, onVideoCardClick, selectedPla
             className="flex items-center gap-4 p-3 bg-white/20 dark:bg-white/5 rounded-xl cursor-pointer hover:bg-white/30 dark:hover:bg-white/10 transition-colors duration-200"
             onClick={() => {
               if (selectedPlatform === 'youtube') {
-                onVideoCardClick(content.videoId, content.title, 'youtube');
+                onVideoCardClick({
+                  contentId: content.videoId,
+                  title: content.title,
+                  platform: 'youtube'});
               } else if (selectedPlatform === 'reddit') {
-                onVideoCardClick(content.post_id, content.title, 'reddit');
+                onVideoCardClick({
+                  contentId: content.post_id, 
+                  title: content.title, 
+                  platform: 'reddit'});
               }
             }}
           >

--- a/src/features/content-modals/ui/CommentAnalysisView.jsx
+++ b/src/features/content-modals/ui/CommentAnalysisView.jsx
@@ -3,12 +3,12 @@ import { ThumbsUp, MessageCircle } from 'lucide-react';
 
 const CommentAnalysisView = ({ data }) => {
   if (!data) {
-    return <div className="text-center text-gray-500">데이터가 없습니다.</div>;
+    return <div className="text-center text-gray-500">충분한 댓글 데이터가 없습니다.</div>;
   }
 
-  console.log("CommentAnalysisView data:", data);
-  const { topComments, atmosphere } = data;
-  console.log("CommentAnalysisView topComments:", topComments);
+  // atmosphere 그대로, topComments는 API 응답 키 두 가지 모두 대응
+  const atmosphere = data.atmosphere;
+  const topComments = data.topComments || data["top comments"];
 
   return (
     <div className="space-y-4">
@@ -20,22 +20,28 @@ const CommentAnalysisView = ({ data }) => {
         <h4 className="font-semibold mb-2 text-gray-800 dark:text-gray-200">인기 댓글</h4>
         <div className="max-h-60 overflow-y-auto pr-2">
           <ul className="space-y-3">
-            {topComments && topComments.map((comment, index) => (
-              <li key={index} className="p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
-                <p className="text-sm font-semibold text-gray-800 dark:text-gray-200 mb-1">{comment.author}</p>
-                <p className="text-sm text-gray-600 dark:text-gray-400">{comment.text}</p>
-                <div className="flex items-center gap-4 mt-2 text-xs text-gray-500 dark:text-gray-500">
-                  <div className="flex items-center gap-1">
+            {Array.isArray(topComments) && topComments.length > 0 ? (
+              topComments.map((comment, index) => (
+                <li key={index} className="p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
+                  <p className="text-sm font-semibold text-gray-800 dark:text-gray-200 mb-1">
+                    {comment.author}
+                  </p>
+                  <p className="text-sm text-gray-600 dark:text-gray-400">{comment.text}</p>
+                  <div className="flex items-center gap-4 mt-2 text-xs text-gray-500 dark:text-gray-500">
+                    <div className="flex items-center gap-1">
                       <ThumbsUp className="w-3 h-3" />
                       <span>{comment.likes_or_score}</span>
-                  </div>
-                  <div className="flex items-center gap-1">
+                    </div>
+                    <div className="flex items-center gap-1">
                       <MessageCircle className="w-3 h-3" />
                       <span>{comment.replies}</span>
+                    </div>
                   </div>
-                </div>
-              </li>
-            ))}
+                </li>
+              ))
+            ) : (
+              <li className="text-gray-500 text-sm">인기 댓글이 없습니다.</li>
+            )}
           </ul>
         </div>
       </div>

--- a/src/features/content-modals/ui/ContentListView.jsx
+++ b/src/features/content-modals/ui/ContentListView.jsx
@@ -78,7 +78,7 @@ function ContentListView({
               sortBy: sortOrder,
               // No pagination here, fetch all and paginate after merge
             });
-            const formattedYtData = ytData.videos.map(v => ({...v, platform: 'YouTube', uploadDate: v.publishedAt, id: v.videoId, views: v.statistics?.viewCount, likes: v.statistics?.likeCount, comments: v.statistics?.commentCount}));
+            const formattedYtData = ytData.videos.map(v => ({...v, platform: 'YouTube', uploadDate: v.publishedAt, id: v.videoId, title: v.title, views: v.statistics?.viewCount, likes: v.statistics?.likeCount, comments: v.statistics?.commentCount}));
             allData.push(...formattedYtData);
           } else if (selectedPlatform === 'youtube') {
              setError('YouTube 채널이 연결되지 않았습니다.');
@@ -331,7 +331,7 @@ function ContentListView({
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.3, delay: index * 0.05 }}
-                onClick={() => open_preview_modal(content)}
+                onClick={() => open_preview_modal({...content, title: content.title,})}
               >
                 <motion.div
                   whileHover={{ y: -8, scale: 1.02 }}

--- a/src/pages/AnalyticsPage.jsx
+++ b/src/pages/AnalyticsPage.jsx
@@ -14,9 +14,9 @@ const AnalyticsPage = () => {
     const videoIdFromUrl = searchParams.get('videoId');
     const platformFromUrl = searchParams.get('platform');
     if (videoIdFromUrl) {
-      const video = mockContentData.find(item => item.id === parseInt(videoIdFromUrl));
-      setSelectedVideoId(videoIdFromUrl);
-      setSelectedVideoTitle(video ? video.title : `Video ${videoIdFromUrl}`);
+      // const video = mockContentData.find(item => item.id === parseInt(videoIdFromUrl));
+      // setSelectedVideoId(videoIdFromUrl);
+      // setSelectedVideoTitle(video ? video.title : `Video ${videoIdFromUrl}`);
       setSelectedPlatform(platformFromUrl || 'youtube');
     } else {
       setSelectedVideoId(null);
@@ -32,11 +32,12 @@ const AnalyticsPage = () => {
     setSearchParams(searchParams);
   };
 
-  const handleOpenAnalysisModal = (id, title, platform) => {
-    setSelectedVideoId(id);
+  const handleOpenAnalysisModal = ({ contentId, title, platform }) => {
+    setSelectedVideoId(contentId);
     setSelectedVideoTitle(title);
     setSelectedPlatform(platform);
-    searchParams.set('videoId', id);
+    searchParams.set('videoId', contentId);
+    searchParams.set('title', title);
     searchParams.set('platform', platform);
     setSearchParams(searchParams);
   };


### PR DESCRIPTION
### 플랫폼 상태 초기화 순서 개선 (인증 완료 후 상태 조회 시작)
- status 호출부분을 수정

### 그래프 및 차트 부분
- 트래픽 그래프 API 변경 (videoId → 기간 기반 range API)
- traffic-source-summary API 구조 변경 (videoId 제거, range 기반)
- DemographicsChart mock 데이터 제거 및 API 연동
- Reddit 플랫폼일 때 차트/그래프 조회 제외 


### 분석탭 모달창 부분 
- 모달창에서 Video ID 대신 Video Title 표시
- Reddit 플랫폼에서도 embed된 유튜브 링크가 보이던 문제 수정
- 인기 댓글이 보이지 않는 문제 수정