### PR TITLE
feat(Analytics): 분석 페이지 UI/UX 전면 개선

### DIFF
--- a/src/common/ui/AudienceDemographicsChart.jsx
+++ b/src/common/ui/AudienceDemographicsChart.jsx
@@ -10,7 +10,7 @@ const AudienceDemographicsChart = ({ data }) => {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5, delay: 0.4 }}
     >
-      <GlassCard className="p-6" hover={true}>
+      <GlassCard className="p-6" hover={false}>
         <motion.div 
           className="flex items-center gap-4 mb-6"
           initial={{ opacity: 0, x: -20 }}

--- a/src/common/ui/TrafficSourceChart.jsx
+++ b/src/common/ui/TrafficSourceChart.jsx
@@ -7,13 +7,13 @@ import { traffic_source_data } from '@/domain/dashboard/logic/dashboard-constant
 import { useAnalyticsStore } from '@/domain/analytics/logic/store';
 import { cn } from '@/common/utils/ui-utils';
 
-// 프로젝트 표준 그라데이션 색상 시스템 (5개 카테고리용)
+// 구분하기 쉬운 다양한 색상 시스템 (5개 카테고리용)
 const GRADIENT_COLORS = [
-  'hsl(217, 91%, 60%)', // 파란색 기본 - 검색
-  'hsl(262, 83%, 58%)', // 보라색 기본 - 추천/탐색
-  'hsl(245, 58%, 51%)', // 파란색-보라색 중간 - 채널/구독
-  'hsl(280, 100%, 70%)', // 밝은 보라색 - 외부
-  'hsl(200, 80%, 55%)' // 청록색 - 기타
+  'hsl(217, 91%, 60%)', // 파란색 - 검색
+  'hsl(142, 71%, 45%)', // 초록색 - 추천/탐색  
+  'hsl(25, 95%, 53%)', // 주황색 - 채널/구독
+  'hsl(348, 83%, 47%)', // 빨간색 - 외부
+  'hsl(262, 83%, 58%)' // 보라색 - 기타
 ];
 
 // 커스텀 툴팁 컴포넌트
@@ -63,7 +63,6 @@ const CustomLegend = ({ payload }) => (
         initial={{ opacity: 0, x: -20 }}
         animate={{ opacity: 1, x: 0 }}
         transition={{ duration: 0.4, delay: 0.9 + index * 0.1, ease: [0.16, 1, 0.3, 1] }}
-        whileHover={{ scale: 1.05, y: -2 }}
       >
         <div 
           className="w-3 h-3 rounded-full"
@@ -152,7 +151,7 @@ const TrafficSourceChart = () => {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, delay: 0.2, ease: [0.16, 1, 0.3, 1] }}
     >
-      <GlassCard className="p-6" hover={true}>
+      <GlassCard className="p-6" hover={false}>
         {/* 헤더 섹션 */}
         <motion.div 
           className="flex items-center gap-4 mb-6"

--- a/src/common/ui/glass-card.jsx
+++ b/src/common/ui/glass-card.jsx
@@ -22,7 +22,7 @@ const GlassCard = ({
   return (
     <motion.div
       whileHover={hover ? { y: -4 } : {}}
-      className={`backdrop-blur-xl bg-white/20 dark:bg-white/5 border border-white/30 dark:border-white/10 rounded-2xl p-6 shadow-xl transition-all duration-300 ${className}`}
+      className={`backdrop-blur-xl bg-gray-50/70 dark:bg-white/5 border border-gray-200/60 dark:border-white/10 rounded-2xl p-6 shadow-lg transition-all duration-300 ${className}`}
     >
       {children}
     </motion.div>

--- a/src/containers/AnalyticsFilterSidebar/index.jsx
+++ b/src/containers/AnalyticsFilterSidebar/index.jsx
@@ -7,8 +7,6 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { 
-  Play, 
-  MessageSquare, 
   ChevronDown, 
   ArrowLeft,
   Check,
@@ -16,6 +14,8 @@ import {
   BarChart3,
   PieChart
 } from 'lucide-react';
+import YoutubeIcon from '@/assets/images/button/Youtube_Icon.svg';
+import RedditIcon from '@/assets/images/button/Reddit_Icon.svg';
 import { useAnalyticsStore } from '@/domain/analytics/logic/store';
 import { MeaireLogo } from '@/common/ui/meaire-logo';
 import { usePageStore } from '@/common/stores/page-store';
@@ -52,8 +52,8 @@ const AnalyticsFilterSidebar = ({
     custom: '직접 설정'
   };
   const platform_options = [
-    { id: 'youtube', label: 'YouTube', icon: Play, color: 'text-red-600' },
-    { id: 'reddit', label: 'Reddit', icon: MessageSquare, color: 'text-orange-600' }
+    { id: 'youtube', label: 'YouTube', icon: YoutubeIcon, color: 'text-red-600', isSvg: true },
+    { id: 'reddit', label: 'Reddit', icon: RedditIcon, color: 'text-orange-600', isSvg: true }
   ];
 
   return (
@@ -85,14 +85,14 @@ const AnalyticsFilterSidebar = ({
                   whileTap={{ scale: 0.98 }}
                   className={`w-full flex items-center gap-3 px-4 py-3 rounded-xl transition-all duration-200 ${
                     isSelected 
-                      ? 'bg-blue-500 text-white shadow-lg' 
+                      ? 'bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-500/30 text-gray-800 dark:text-white shadow-lg' 
                       : 'text-gray-700 dark:text-gray-300 hover:bg-white/30 dark:hover:bg-white/20'
                   }`}
                 >
-                  <Icon className={`w-4 h-4 ${isSelected ? 'text-white' : 'text-blue-500'}`} />
+                  <Icon className={`w-4 h-4 ${isSelected ? 'text-gray-800 dark:text-white' : 'text-purple-500/80'}`} />
                   <div className="text-left">
                     <div className="font-medium">{viewOption.label}</div>
-                    <div className={`text-xs ${isSelected ? 'text-blue-100' : 'text-gray-500 dark:text-gray-400'}`}>
+                    <div className={`text-xs ${isSelected ? 'text-gray-600 dark:text-gray-300' : 'text-gray-500 dark:text-gray-400'}`}>
                       {viewOption.description}
                     </div>
                   </div>
@@ -124,7 +124,7 @@ const AnalyticsFilterSidebar = ({
                 'rounded-xl',
                 'transition-all',
                 'duration-200',
-                isSelected ? 'bg-blue-500 text-white shadow-lg' : 'text-gray-700 dark:text-gray-300',
+                isSelected ? 'bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-500/30 text-gray-800 dark:text-white shadow-lg' : 'text-gray-700 dark:text-gray-300',
                 !isConnected ? 'opacity-50 cursor-not-allowed' : (isSelected ? '' : 'hover:bg-white/30 dark:hover:bg-white/20')
               ].join(' ');
 
@@ -137,7 +137,11 @@ const AnalyticsFilterSidebar = ({
                   className={buttonClasses}
                   disabled={!isConnected}
                 >
-                  <Icon className={`w-4 h-4 ${isSelected ? 'text-white' : platform.color}`} />
+                  {platform.isSvg ? (
+                    <img src={Icon} alt={platform.label} className="w-4 h-4" />
+                  ) : (
+                    <Icon className={`w-4 h-4 ${isSelected ? 'text-white' : platform.color}`} />
+                  )}
                   <span>{platform.label}</span>
                   {!isConnected && <Lock className="w-4 h-4 ml-auto text-gray-500 dark:text-gray-400" />}
                 </motion.button>
@@ -188,7 +192,7 @@ const AnalyticsFilterSidebar = ({
                           whileTap={{ scale: 0.98 }}
                           className={`w-full text-left px-3 py-3 rounded-lg transition-all duration-200 flex items-center justify-between ${
                             selected_period === option.id
-                              ? 'bg-blue-500 text-white shadow-lg'
+                              ? 'bg-gradient-to-r from-blue-500/20 to-purple-500/20 border border-blue-500/30 text-gray-800 dark:text-white shadow-lg'
                               : 'text-gray-700 dark:text-gray-300 hover:bg-white/30 dark:hover:bg-white/20'
                           }`}
                         >

--- a/src/features/analytics/ui/PerformanceHighlight.jsx
+++ b/src/features/analytics/ui/PerformanceHighlight.jsx
@@ -1,0 +1,235 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Trophy, TrendingUp, Eye, Heart, MessageSquare, ArrowUp, ArrowDown } from 'lucide-react';
+import GlassCard from '@/common/ui/glass-card';
+import { format_number_korean } from '@/domain/dashboard/logic/dashboard-utils';
+
+/**
+ * 성과 하이라이트 컴포넌트
+ * 현재 API 데이터를 활용하여 최고 성과 콘텐츠와 성장 지표를 표시
+ */
+const PerformanceHighlight = ({ contentData, summaryData, selectedPlatform }) => {
+  // 최고 성과 콘텐츠 찾기
+  const getTopPerformer = () => {
+    if (!contentData || !Array.isArray(contentData) || contentData.length === 0) {
+      return null;
+    }
+
+    // 플랫폼별 정렬 기준
+    const sortKey = selectedPlatform === 'youtube' ? 'statistics.viewCount' : 'upvotes';
+    
+    return contentData.reduce((top, current) => {
+      const currentValue = selectedPlatform === 'youtube' 
+        ? (current.statistics?.viewCount || 0)
+        : (current.upvotes || current.score || 0);
+      
+      const topValue = selectedPlatform === 'youtube'
+        ? (top.statistics?.viewCount || 0)
+        : (top.upvotes || top.score || 0);
+
+      return currentValue > topValue ? current : top;
+    });
+  };
+
+  // 최저 성과 콘텐츠 찾기
+  const getWorstPerformer = () => {
+    if (!contentData || !Array.isArray(contentData) || contentData.length === 0) {
+      return null;
+    }
+    
+    return contentData.reduce((worst, current) => {
+      const currentValue = selectedPlatform === 'youtube' 
+        ? (current.statistics?.viewCount || 0)
+        : (current.upvotes || current.score || 0);
+      
+      const worstValue = selectedPlatform === 'youtube'
+        ? (worst.statistics?.viewCount || 0)
+        : (worst.upvotes || worst.score || 0);
+
+      return currentValue < worstValue ? current : worst;
+    });
+  };
+
+  // 성과 차이 계산
+  const getPerformanceDifference = (best, worst) => {
+    if (!best || !worst) return null;
+    
+    const bestValue = selectedPlatform === 'youtube' 
+      ? (best.statistics?.viewCount || 0)
+      : (best.upvotes || best.score || 0);
+      
+    const worstValue = selectedPlatform === 'youtube'
+      ? (worst.statistics?.viewCount || 0)
+      : (worst.upvotes || worst.score || 0);
+
+    if (worstValue === 0) return null;
+    return Math.round((bestValue / worstValue) * 10) / 10; // 소수점 1자리까지
+  };
+
+  // 성장률 계산 (간단한 참여율 기준)
+  const getEngagementRate = () => {
+    if (!summaryData) return 0;
+    
+    const totalData = summaryData.total || summaryData;
+    
+    if (selectedPlatform === 'youtube') {
+      const views = totalData?.total_view_count || 0;
+      const likes = totalData?.total_like_count || 0;
+      const comments = totalData?.total_comment_count || 0;
+      
+      if (views === 0) return 0;
+      return ((likes + comments * 2) / views * 100).toFixed(1);
+    } else {
+      const upvotes = totalData?.total_upvote_count || 0;
+      const comments = totalData?.total_comment_count || 0;
+      
+      if (upvotes === 0) return 0;
+      return ((comments / upvotes) * 100).toFixed(1);
+    }
+  };
+
+  const topPerformer = getTopPerformer();
+  const worstPerformer = getWorstPerformer();
+  const engagementRate = getEngagementRate();
+  const performanceDiff = getPerformanceDifference(topPerformer, worstPerformer);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: 0.3 }}
+    >
+      <GlassCard className="p-6 min-h-[400px]" hover={false}>
+        <div className="flex items-center gap-4 mb-5">
+          <div className="w-12 h-12 rounded-2xl bg-gradient-to-br from-yellow-500/30 to-orange-500/30 backdrop-blur-sm border border-white/40 dark:border-white/20 flex items-center justify-center shadow-lg">
+            <Trophy className="w-5 h-5 text-yellow-600 dark:text-yellow-400" />
+          </div>
+          <div>
+            <h3 className="text-xl font-semibold text-gray-800 dark:text-white">
+              성과 하이라이트
+            </h3>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              주요 성과 지표와 최고 콘텐츠
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {/* 최고 성과 콘텐츠 */}
+          {topPerformer ? (
+            <div className="bg-gradient-to-r from-yellow-50/50 to-orange-50/50 dark:from-yellow-950/20 dark:to-orange-950/20 rounded-xl p-3 border border-yellow-200/30 dark:border-yellow-800/30">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-xs font-medium text-yellow-700 dark:text-yellow-400 uppercase tracking-wide">
+                  🏆 TOP 콘텐츠
+                </span>
+                <div className="text-xs text-gray-600 dark:text-gray-400">
+                  {selectedPlatform === 'youtube' ? (
+                    <div className="flex items-center gap-1">
+                      <Eye className="w-3 h-3" />
+                      <span>{format_number_korean(topPerformer.statistics?.viewCount || 0)}</span>
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-1">
+                      <TrendingUp className="w-3 h-3" />
+                      <span>{format_number_korean(topPerformer.upvotes || topPerformer.score || 0)}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <h4 className="text-sm font-medium text-gray-800 dark:text-white line-clamp-2 leading-tight">
+                {topPerformer.title}
+              </h4>
+            </div>
+          ) : (
+            <div className="bg-gray-50/50 dark:bg-gray-800/50 rounded-xl p-3 border border-gray-200/30 dark:border-gray-700/30">
+              <p className="text-sm text-gray-600 dark:text-gray-400 text-center">
+                콘텐츠 데이터를 불러오는 중...
+              </p>
+            </div>
+          )}
+
+          {/* 성과 지표 */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="bg-blue-50/50 dark:bg-blue-950/20 rounded-lg p-3 border border-blue-200/30 dark:border-blue-800/30">
+              <div className="flex items-center gap-2 mb-1">
+                <TrendingUp className="w-4 h-4 text-blue-600 dark:text-blue-400" />
+                <span className="text-xs font-medium text-blue-700 dark:text-blue-400">
+                  참여율
+                </span>
+              </div>
+              <p className="text-lg font-semibold text-blue-800 dark:text-blue-300">
+                {engagementRate}%
+              </p>
+            </div>
+
+            <div className="bg-green-50/50 dark:bg-green-950/20 rounded-lg p-3 border border-green-200/30 dark:border-green-800/30">
+              <div className="flex items-center gap-2 mb-1">
+                <Heart className="w-4 h-4 text-green-600 dark:text-green-400" />
+                <span className="text-xs font-medium text-green-700 dark:text-green-400">
+                  총 콘텐츠
+                </span>
+              </div>
+              <p className="text-lg font-semibold text-green-800 dark:text-green-300">
+                {contentData ? contentData.length : 0}개
+              </p>
+            </div>
+          </div>
+
+          {/* 성과 비교 섹션 */}
+          {topPerformer && worstPerformer && topPerformer !== worstPerformer && (
+            <div className="mt-4 pt-4 border-t border-gray-200/30 dark:border-gray-700/30">
+              <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3 flex items-center gap-2">
+                📊 성과 비교
+                {performanceDiff && (
+                  <span className="text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 px-2 py-0.5 rounded-full">
+                    {performanceDiff}x 차이
+                  </span>
+                )}
+              </h4>
+              
+              <div className="grid grid-cols-2 gap-3">
+                {/* 최고 성과 */}
+                <div className="bg-green-50/50 dark:bg-green-950/20 rounded-lg p-2 border border-green-200/30 dark:border-green-800/30">
+                  <div className="flex items-center gap-2 mb-1">
+                    <ArrowUp className="w-3 h-3 text-green-600 dark:text-green-400" />
+                    <span className="text-xs font-medium text-green-700 dark:text-green-400">BEST</span>
+                  </div>
+                  <h5 className="text-xs font-medium text-gray-800 dark:text-white line-clamp-1 mb-1">
+                    {topPerformer.title}
+                  </h5>
+                  <p className="text-xs text-green-700 dark:text-green-400">
+                    {selectedPlatform === 'youtube' ? (
+                      `${format_number_korean(topPerformer.statistics?.viewCount || 0)} 조회`
+                    ) : (
+                      `${format_number_korean(topPerformer.upvotes || topPerformer.score || 0)} 업보트`
+                    )}
+                  </p>
+                </div>
+
+                {/* 최저 성과 */}
+                <div className="bg-red-50/50 dark:bg-red-950/20 rounded-lg p-2 border border-red-200/30 dark:border-red-800/30">
+                  <div className="flex items-center gap-2 mb-1">
+                    <ArrowDown className="w-3 h-3 text-red-600 dark:text-red-400" />
+                    <span className="text-xs font-medium text-red-700 dark:text-red-400">WORST</span>
+                  </div>
+                  <h5 className="text-xs font-medium text-gray-800 dark:text-white line-clamp-1 mb-1">
+                    {worstPerformer.title}
+                  </h5>
+                  <p className="text-xs text-red-700 dark:text-red-400">
+                    {selectedPlatform === 'youtube' ? (
+                      `${format_number_korean(worstPerformer.statistics?.viewCount || 0)} 조회`
+                    ) : (
+                      `${format_number_korean(worstPerformer.upvotes || worstPerformer.score || 0)} 업보트`
+                    )}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </GlassCard>
+    </motion.div>
+  );
+};
+
+export default React.memo(PerformanceHighlight);


### PR DESCRIPTION
## **작업 개요**

프로젝트의 전반적인 **디자인 통일성**과 **사용자 경험(UX)**을 향상시키기 위해 분석 페이지(`AnalyticsPage`)의 UI/UX를 전면적으로 개선했습니다. 이 변경사항은 시각적 일관성을 높이고, 불필요한 동적 효과를 제거하여 더욱 안정적인 대시보드 경험을 제공하는 데 중점을 두었습니다.

## **주요 변경사항**

- **디자인 시스템 통일:**
    - 사이드바 버튼 색상을 프로젝트의 톤앤매너에 맞춰 **보라색 그라데이션**으로 통일했습니다.
    - YouTube 및 Reddit 아이콘을 실제 **SVG 파일**로 교체하여 브랜드 일관성을 확보했습니다.
    - 업로드된 콘텐츠 번호 박스의 색상도 사이드바와 동일하게 변경했습니다.
- **UI/UX 개선:**
    - 시청자 분포 차트와 트래픽 소스 차트의 불필요한 **호버 효과를 제거**하여 보다 정적인 대시보드 스타일을 구현했습니다.
    - KPI(핵심 성과 지표) 카드의 호버 효과를 제거하여 사용자에게 더욱 안정적인 느낌을 줍니다.
    - 성과 하이라이트와 업로드된 콘텐츠 박스의 높이를 완벽하게 맞춰 레이아웃의 정렬 상태를 개선했습니다.
- **데이터 시각화 및 기능:**
    - 트래픽 소스 차트의 색상을 파란색 계열에서 **다양한 색상**으로 변경하여 데이터의 구분성을 향상시켰습니다.
    - 사용자가 데이터를 효율적으로 탐색할 수 있도록 **필터링 기능**(`최신순`, `오래된순`, `조회수순`, `좋아요순`, `댓글순`)을 구현했습니다.

## **테스트 방법**

1. 로컬 환경에서 개발 서버를 실행합니다.
2. `AnalyticsPage`로 이동하여 변경된 디자인을 확인합니다.
3. 다양한 필터링 옵션을 클릭하여 기능이 정상적으로 동작하는지 확인합니다.
4. 새롭게 추가된 아이콘 및 색상이 의도대로 적용되었는지 검토합니다.

## **피드백 요청**

이번 UI/UX 개선 작업에 대해 디자인 및 기능적 측면에서 자유롭게 의견을 남겨주시면 감사하겠습니다.

---